### PR TITLE
Work around error message from esptool.py

### DIFF
--- a/components/esp32/ld/esp32.project.ld.in
+++ b/components/esp32/ld/esp32.project.ld.in
@@ -170,6 +170,11 @@ SECTIONS
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
+    /* For some reason the ESP tools want to write the SHA256 at offset 0xb0
+     * and it has 32 bytes of data, so we reserve space for that. */
+    _checksum_buffer = ABSOLUTE(.);
+    . += 208;
+    _checksum_buffer_end = ABSOLUTE(.);
     _bt_data_start = ABSOLUTE(.);
     *libbt.a:(.data .data.*)
     . = ALIGN (4);


### PR DESCRIPTION
Build is sometimes broken by esptool complaining that "Contents of
segment at SHA256 digest offset 0x%x are not all zero. Refusing to
overwrite.".  This reserves space for the SHA256 digest although
it remains mysterious what the logic behind this feature is.