### PR TITLE
Sha256 patch fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 
 [submodule "components/esptool_py/esptool"]
 	path = components/esptool_py/esptool
-	url = ../../espressif/esptool.git
+	url = https://github.com/toitware/esptool.git
 
 [submodule "components/bt/controller/lib"]
 	path = components/bt/controller/lib

--- a/components/bootloader_support/include/esp_app_format.h
+++ b/components/bootloader_support/include/esp_app_format.h
@@ -89,7 +89,8 @@ typedef struct {
 #define ESP_APP_DESC_MAGIC_WORD 0xABCD5432  /*!< The magic word for the esp_app_desc structure that is in DROM. */
 
 /**
- * @brief Description about application.
+ * @brief Description about application.  Any changes to this struct affect the
+ * offset in the --elf-sha256-offset option to esptool!
  */
 typedef struct {
     uint32_t magic_word;        /*!< Magic word ESP_APP_DESC_MAGIC_WORD */

--- a/components/esp32/ld/esp32.project.ld.in
+++ b/components/esp32/ld/esp32.project.ld.in
@@ -170,11 +170,6 @@ SECTIONS
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
-    /* For some reason the ESP tools want to write the SHA256 at offset 0xb0
-     * and it has 32 bytes of data, so we reserve space for that. */
-    _checksum_buffer = ABSOLUTE(.);
-    . += 208;
-    _checksum_buffer_end = ABSOLUTE(.);
     _bt_data_start = ABSOLUTE(.);
     *libbt.a:(.data .data.*)
     . = ALIGN (4);
@@ -257,7 +252,7 @@ SECTIONS
   ASSERT(((_bss_end - ORIGIN(dram0_0_seg)) <= LENGTH(dram0_0_seg)),
           "DRAM segment data does not fit.")
 
-  .flash.rodata :
+  .flash.rodata :  /* esptool.py looks for this name to find the app version info */
   {
     _rodata_start = ABSOLUTE(.);
 

--- a/components/esptool_py/Makefile.projbuild
+++ b/components/esptool_py/Makefile.projbuild
@@ -40,7 +40,8 @@ endif
 endif
 
 ifndef IS_BOOTLOADER_BUILD
-ESPTOOL_ELF2IMAGE_OPTIONS += --elf-sha256-offset 0xb0
+# Coordinate with changes to esp_app_desc_t!
+ESPTOOL_ELF2IMAGE_OPTIONS += --elf-sha256-offset 0x90
 endif
 
 ESPTOOLPY_WRITE_FLASH=$(ESPTOOLPY_SERIAL) write_flash $(if $(CONFIG_ESPTOOLPY_COMPRESSED),-z,-u) $(ESPTOOL_WRITE_FLASH_OPTIONS)

--- a/components/esptool_py/project_include.cmake
+++ b/components/esptool_py/project_include.cmake
@@ -43,7 +43,8 @@ string(REPLACE ";" " " ESPTOOLPY_WRITE_FLASH_STR
     "write_flash ${ESPTOOLPY_FLASH_OPTIONS} ${ESPTOOLPY_EXTRA_FLASH_OPTIONS} ${ESPTOOLPY_COMPRESSED_OPT}")
 
 if(NOT BOOTLOADER_BUILD)
-    set(ESPTOOLPY_ELF2IMAGE_OPTIONS --elf-sha256-offset 0xb0)
+    # Coordinate with changes to esp_app_desc_t!
+    set(ESPTOOLPY_ELF2IMAGE_OPTIONS --elf-sha256-offset 0x90)
 endif()
 
 if(CONFIG_SECURE_BOOT_ENABLED AND


### PR DESCRIPTION
This also rolls to the latest esptool, which is about 4 commits ahead of what upstream esp-idf was using.