### PR TITLE
Manually patched code from tim-nordell-nimbelink:feature/deep_sleep_f…

### DIFF
--- a/components/bootloader/Kconfig.projbuild
+++ b/components/bootloader/Kconfig.projbuild
@@ -388,6 +388,26 @@ menu "Security features"
 
     endchoice
 
+    config BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+        bool "Skip image validation when exiting deep sleep"
+        depends on (SECURE_BOOT_ENABLED && SECURE_BOOT_INSECURE) || !SECURE_BOOT_ENABLED
+        select BOOTLOADER_RESERVE_RTC
+        default N
+        help
+            This option disables the normal validation of an image coming out of
+            deep sleep (checksums, SHA256, and signature).  This is a trade-off
+            between wakeup performance from deep sleep, and image integrity checks.
+
+            Only enable this if you know what you are doing.  It should not be used
+            in conjunction with using deep_sleep() entry and changing the active OTA
+            partition as this would skip the validation upon first load of the new
+            OTA partition.
+
+    config BOOTLOADER_RESERVE_RTC
+        hex
+        default 0x10 if BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+        default 0
+
     config SECURE_BOOT_INSECURE
         bool "Allow potentially insecure options"
         depends on SECURE_BOOT_ENABLED

--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -47,7 +47,8 @@ typedef enum {
     ESP_IMAGE_VERIFY,        /* Verify image contents, load metadata. Print errors. */
     ESP_IMAGE_VERIFY_SILENT, /* Verify image contents, load metadata. Don't print errors. */
 #ifdef BOOTLOADER_BUILD
-    ESP_IMAGE_LOAD,          /* Verify image contents, load to memory. Print errors. */
+    ESP_IMAGE_LOAD,             /* Verify image contents, load to memory. Print errors. */
+    ESP_IMAGE_LOAD_NO_VALIDATE, /* Load to memory. Print errors. */
 #endif
 } esp_image_load_mode_t;
 
@@ -133,6 +134,29 @@ esp_err_t esp_image_verify(esp_image_load_mode_t mode, const esp_partition_pos_t
  * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
  */
 esp_err_t bootloader_load_image(const esp_partition_pos_t *part, esp_image_metadata_t *data);
+
+/**
+ * @brief Load an app image without verification (available only in space of bootloader).
+ *
+ * If encryption is enabled, data will be transparently decrypted.
+ *
+ * @param part Partition to load the app from.
+ * @param[inout] data Pointer to the image metadata structure which is be filled in by this function.
+ *                    'start_addr' member should be set (to the start address of the image.)
+ *                    Other fields will all be initialised by this function.
+ *
+ * Image validation checks:
+ * - Magic byte.
+ * - Partition smaller than 16MB.
+ * - All segments & image fit in partition.
+ *
+ * @return
+ * - ESP_OK if verify or load was successful
+ * - ESP_ERR_IMAGE_FLASH_FAIL if a SPI flash error occurs
+ * - ESP_ERR_IMAGE_INVALID if the image appears invalid.
+ * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
+ */
+esp_err_t bootloader_load_image_no_verify(const esp_partition_pos_t *part, esp_image_metadata_t *data);
 
 /**
  * @brief Verify the bootloader image.

--- a/components/bootloader_support/src/bootloader_utility.c
+++ b/components/bootloader_support/src/bootloader_utility.c
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <assert.h>
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
@@ -420,11 +421,39 @@ static void set_actual_ota_seq(const bootloader_state_t *bs, int index)
 
 #define TRY_LOG_FORMAT "Trying partition index %d offs 0x%x size 0x%x"
 
+#ifdef CONFIG_BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+typedef struct rtc_reserved_s {
+    int index;
+    esp_partition_pos_t partition;
+} rtc_reserved_t;
+_Static_assert(sizeof(rtc_reserved_t) <= CONFIG_BOOTLOADER_RESERVE_RTC, "Reserved RTC area must exceed size of rtc_reserved_t");
+#endif
+
 void bootloader_utility_load_boot_image(const bootloader_state_t *bs, int start_index)
 {
     int index = start_index;
     esp_partition_pos_t part;
     esp_image_metadata_t image_data;
+
+#ifdef CONFIG_BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+    rtc_reserved_t * const rtc_last_partition = (rtc_reserved_t *)(SOC_RTC_DRAM_HIGH - sizeof(rtc_reserved_t));
+    if (rtc_get_reset_reason(0) == DEEPSLEEP_RESET)
+    {
+        // Check if the RTC cache matches a valid partition configuration
+        part = index_to_partition(bs, rtc_last_partition->index);
+        if(!memcmp(&part, &rtc_last_partition->partition, sizeof(part)) &&
+            check_anti_rollback(&part) &&
+            bootloader_load_image_no_verify(&part, &image_data) == ESP_OK)
+        {
+            ESP_LOGI(TAG, "Skipped validation while loading app from partition at offset 0x%x",
+                    part.offset);
+            load_image(&image_data);
+        }
+    } else {
+        // Otherwise, clear out the last booted partition cache
+        memset(rtc_last_partition, 0, sizeof(*rtc_last_partition));
+    }
+#endif
 
     if(start_index == TEST_APP_INDEX) {
         if (try_load_partition(&bs->test, &image_data)) {
@@ -444,6 +473,10 @@ void bootloader_utility_load_boot_image(const bootloader_state_t *bs, int start_
         ESP_LOGD(TAG, TRY_LOG_FORMAT, index, part.offset, part.size);
         if (check_anti_rollback(&part) && try_load_partition(&part, &image_data)) {
             set_actual_ota_seq(bs, index);
+#ifdef CONFIG_BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+            rtc_last_partition->partition = part;
+            rtc_last_partition->index = index;
+#endif
             load_image(&image_data);
         }
         log_invalid_app_partition(index);
@@ -458,6 +491,10 @@ void bootloader_utility_load_boot_image(const bootloader_state_t *bs, int start_
         ESP_LOGD(TAG, TRY_LOG_FORMAT, index, part.offset, part.size);
         if (check_anti_rollback(&part) && try_load_partition(&part, &image_data)) {
             set_actual_ota_seq(bs, index);
+#ifdef CONFIG_BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
+            rtc_last_partition->partition = part;
+            rtc_last_partition->index = index;
+#endif
             load_image(&image_data);
         }
         log_invalid_app_partition(index);

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -97,7 +97,7 @@ static esp_err_t __attribute__((unused)) verify_simple_hash(bootloader_sha256_ha
 static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_t *part, esp_image_metadata_t *data)
 {
 #ifdef BOOTLOADER_BUILD
-    bool do_load = (mode == ESP_IMAGE_LOAD);
+    bool do_load = (mode == ESP_IMAGE_LOAD || mode == ESP_IMAGE_LOAD_NO_VALIDATE);
 #else
     bool do_load = false; // Can't load the image in app mode
 #endif
@@ -105,6 +105,7 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
     esp_err_t err = ESP_OK;
     // checksum the image a word at a time. This shaves 30-40ms per MB of image size
     uint32_t checksum_word = ESP_ROM_CHECKSUM_INITIAL;
+    uint32_t *checksum = NULL;
     bootloader_sha256_handle_t sha_handle = NULL;
 
     if (data == NULL || part == NULL) {
@@ -125,17 +126,26 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
         goto err;
     }
 
-    // Calculate SHA-256 of image if secure boot is on, or if image has a hash appended
-#ifdef SECURE_BOOT_CHECK_SIGNATURE
-    if (1) {
+#ifdef BOOTLOADER_BUILD
+    if (mode != ESP_IMAGE_LOAD_NO_VALIDATE)
 #else
-    if (data->image.hash_appended) {
+    if (1)
 #endif
-        sha_handle = bootloader_sha256_start();
-        if (sha_handle == NULL) {
-            return ESP_ERR_NO_MEM;
+    {
+        checksum = &checksum_word;
+
+        // Calculate SHA-256 of image if secure boot is on, or if image has a hash appended
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+        if (1) {
+#else
+        if (data->image.hash_appended) {
+#endif
+            sha_handle = bootloader_sha256_start();
+            if (sha_handle == NULL) {
+                return ESP_ERR_NO_MEM;
+            }
+            bootloader_sha256_data(sha_handle, &data->image, sizeof(esp_image_header_t));
         }
-        bootloader_sha256_data(sha_handle, &data->image, sizeof(esp_image_header_t));
     }
 
     ESP_LOGD(TAG, "image header: 0x%02x 0x%02x 0x%02x 0x%02x %08x",
@@ -159,7 +169,7 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
     for(int i = 0; i < data->image.segment_count; i++) {
         esp_image_segment_header_t *header = &data->segments[i];
         ESP_LOGV(TAG, "loading segment header %d at offset 0x%x", i, next_addr);
-        err = process_segment(i, next_addr, header, silent, do_load, sha_handle, &checksum_word);
+        err = process_segment(i, next_addr, header, silent, do_load, sha_handle, checksum);
         if (err != ESP_OK) {
             goto err;
         }
@@ -176,12 +186,13 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
 
     data->image_len = end_addr - data->start_addr;
     ESP_LOGV(TAG, "image start 0x%08x end of last section 0x%08x", data->start_addr, end_addr);
-    if (!esp_cpu_in_ocd_debug_mode()) {
+    if (NULL != checksum) {
         err = verify_checksum(sha_handle, checksum_word, data);
-        if (err != ESP_OK) {
+        if (err != ESP_OK && !esp_cpu_in_ocd_debug_mode()) {
             goto err;
         }
     }
+
     if (data->image_len > part->size) {
         FAIL_LOAD("Image length %d doesn't fit in partition length %d", data->image_len, part->size);
     }
@@ -193,15 +204,22 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
        rewritten the header - rely on esptool.py having verified the bootloader at flashing time, instead.
     */
     if (!is_bootloader) {
-#ifdef SECURE_BOOT_CHECK_SIGNATURE
-        // secure boot images have a signature appended
-        err = verify_secure_boot_signature(sha_handle, data);
+#ifdef BOOTLOADER_BUILD
+        if (mode != ESP_IMAGE_LOAD_NO_VALIDATE)
 #else
-        // No secure boot, but SHA-256 can be appended for basic corruption detection
-        if (sha_handle != NULL && !esp_cpu_in_ocd_debug_mode()) {
-            err = verify_simple_hash(sha_handle, data);
-        }
+        if (1)
+#endif
+        {
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+            // secure boot images have a signature appended
+            err = verify_secure_boot_signature(sha_handle, data);
+#else
+            // No secure boot, but SHA-256 can be appended for basic corruption detection
+            if (sha_handle != NULL && !esp_cpu_in_ocd_debug_mode()) {
+                err = verify_simple_hash(sha_handle, data);
+            }
 #endif // SECURE_BOOT_CHECK_SIGNATURE
+        }
     } else { // is_bootloader
         // bootloader may still have a sha256 digest handle open
         if (sha_handle != NULL) {
@@ -225,7 +243,7 @@ static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_
     }
 
 #ifdef BOOTLOADER_BUILD
-    if (do_load) { // Need to deobfuscate RAM
+    if (ram_obfs_value[0] != 0 && ram_obfs_value[1] != 0 && do_load) { // Need to deobfuscate RAM
         for (int i = 0; i < data->image.segment_count; i++) {
             uint32_t load_addr = data->segments[i].load_addr;
             if (should_load(load_addr)) {
@@ -258,6 +276,15 @@ esp_err_t bootloader_load_image(const esp_partition_pos_t *part, esp_image_metad
 {
 #ifdef BOOTLOADER_BUILD
     return image_load(ESP_IMAGE_LOAD, part, data);
+#else
+    return ESP_FAIL;
+#endif
+}
+
+esp_err_t bootloader_load_image_no_verify(const esp_partition_pos_t *part, esp_image_metadata_t *data)
+{
+#ifdef BOOTLOADER_BUILD
+    return image_load(ESP_IMAGE_LOAD_NO_VALIDATE, part, data);
 #else
     return ESP_FAIL;
 #endif
@@ -396,11 +423,26 @@ err:
 
 static esp_err_t process_segment_data(intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum)
 {
+    // If we are not loading, and the checksum is empty, skip processing this
+    // segment for data
+    if(!do_load && NULL == checksum)
+    {
+        ESP_LOGD(TAG, "skipping checksum for segment");
+        return ESP_OK;
+    }
+
     const uint32_t *data = (const uint32_t *)bootloader_mmap(data_addr, data_len);
     if(!data) {
         ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed",
                  data_addr, data_len);
         return ESP_FAIL;
+    }
+
+    if (NULL == checksum && NULL == sha_handle)
+    {
+        memcpy((void *)load_addr, data, data_len);
+        bootloader_munmap(data);
+        return ESP_OK;
     }
 
 #ifdef BOOTLOADER_BUILD
@@ -416,7 +458,10 @@ static esp_err_t process_segment_data(intptr_t load_addr, uint32_t data_addr, ui
     for (int i = 0; i < data_len; i += 4) {
         int w_i = i/4; // Word index
         uint32_t w = src[w_i];
-        *checksum ^= w;
+        if(NULL != checksum)
+        {
+            *checksum ^= w;
+        }
 #ifdef BOOTLOADER_BUILD
         if (do_load) {
             dest[w_i] = w ^ ((w_i & 1) ? ram_obfs_value[0] : ram_obfs_value[1]);

--- a/components/esp32/ld/esp32.ld
+++ b/components/esp32/ld/esp32.ld
@@ -32,6 +32,10 @@ ASSERT((CONFIG_ESP32_FIXED_STATIC_RAM_SIZE <= 0x2c200),
 #define DRAM0_0_SEG_LEN 0x2c200
 #endif
 
+#ifndef CONFIG_BOOTLOADER_RESERVE_RTC
+#define CONFIG_BOOTLOADER_RESERVE_RTC 0
+#endif
+
 MEMORY
 {
   /* All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
@@ -39,11 +43,11 @@ MEMORY
   are connected to the data port of the CPU and eg allow bytewise access. */
 
   /* IRAM for PRO cpu. Not sure if happy with this, this is MMU area... */
-  iram0_0_seg (RX) :                 org = 0x40080000, len = 0x20000
+  iram0_0_seg (RX) :                 org = 0x40080000, len = 0x20000-CONFIG_BOOTLOADER_RESERVE_RTC
 
   /* Even though the segment name is iram, it is actually mapped to flash
   */
-  iram0_2_seg (RX) :                 org = 0x400D0018, len = 0x330000-0x18
+  iram0_2_seg (RX) :                 org = 0x400D0018, len = 0x330000-0x18-CONFIG_BOOTLOADER_RESERVE_RTC
 
   /*
     (0x18 offset above is a convenience for the app binary image generation. Flash cache has 64KB pages. The .bin file


### PR DESCRIPTION
…ast_wake

This reduces bootloader timer from 361ms to 45ms on ESP32.
Default off. Set 
   BOOT_SKIP_VALIDATE_OUT_OF_DEEP_SLEEP
make menuconfig to turn it on.