### PR TITLE
Make malloc heap iteration more flexible

### DIFF
--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -362,11 +362,11 @@ void heap_caps_set_thread_tag(void* tag)
     multi_heap_set_thread_tag(tag);
 }
 
-void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback)
+void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
 {
     heap_t *heap;
     SLIST_FOREACH(heap, &registered_heaps, next) {
-        multi_heap_iterate_tagged_memory_areas(heap->heap, user_data, tag, callback);
+        multi_heap_iterate_tagged_memory_areas(heap->heap, user_data, tag, callback, flags);
     }
 }
 

--- a/components/heap/include/esp_heap_caps.h
+++ b/components/heap/include/esp_heap_caps.h
@@ -40,6 +40,16 @@ extern "C" {
 #define MALLOC_CAP_INVALID          (1<<31) ///< Memory can't be used / list end marker
 
 /**
+ * Flags for heap_caps_iterate_tagged_memory_areas.
+ */
+#define MALLOC_ITERATE_UNLOCKED        (1<<0) /// Dangerous options for use in a crash handler only - avoid deadlocks by not using locking.
+#define MALLOC_ITERATE_ALL_ALLOCATIONS (1<<1) /// Iterate all allocations, not just the ones where the tag matches.
+#define MALLOC_ITERATE_UNALLOCATED     (1<<2) /// Call back for free areas.  Tags are as follows for this:
+
+#define MALLOC_ITERATE_TAG_FREE          (-1)  /// Memory is free and could be allocated.
+#define MALLOC_ITERATE_TAG_HEAP_OVERHEAD (-2)  /// Memory is used by malloc for internal accounting etc.
+
+/**
  * @brief Allocate a chunk of memory which has the given capabilities
  *
  * Equivalent semantics to libc malloc(), for capability-aware memory.
@@ -333,8 +343,9 @@ void heap_caps_set_thread_tag(void *tag);
  * @param user_data   A value that will be passed to each invocation of the callback.
  * @param tag         An opaque piece of data that was passed to heap_caps_set_thread_tag.
  * @param callback    A function to be called for each not-yet-freed memory area with the given tag.
+ * @param flags       Zero or a set of flags, 'or'ed together from MALLOC_ITERATE_UNLOCKED, MALLOC_ITERATE_ALL_ALLOCATIONS and MALLOC_ITERATE_UNALLOCATED.
  */
-void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback);
+void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
 
 #ifdef __cplusplus
 }

--- a/components/heap/include/multi_heap.h
+++ b/components/heap/include/multi_heap.h
@@ -177,7 +177,7 @@ void multi_heap_get_info(multi_heap_handle_t heap, multi_heap_info_t *info);
 #define MULTI_HEAP_THREAD_TAG_INDEX 1
 
 void multi_heap_set_thread_tag(void *user_data);
-void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback);
+void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
 
 #ifdef __cplusplus
 }

--- a/components/heap/third_party/dartino/cmpctmalloc.h
+++ b/components/heap/third_party/dartino/cmpctmalloc.h
@@ -12,4 +12,12 @@ void cmpct_free_impl(multi_heap_handle_t heap, void *p);
 void cmpct_get_info_impl(multi_heap_handle_t heap, multi_heap_info_t *info);
 void *cmpct_malloc_impl(multi_heap_handle_t heap, size_t size);
 void *cmpct_realloc_impl(multi_heap_handle_t heap, void *p, size_t size);
-void cmpct_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback);
+void cmpct_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
+
+// Flags for heap iteration.  Coordinate with constants in esp_heap_caps.h
+#define CMPCTMALLOC_ITERATE_UNLOCKED 1
+#define CMPCTMALLOC_ITERATE_ALL_ALLOCATIONS 2
+#define CMPCTMALLOC_ITERATE_UNUSED   4
+
+#define CMPCTMALLOC_ITERATE_TAG_FREE          (-1)  /// Memory is free and could be allocated.
+#define CMPCTMALLOC_ITERATE_TAG_HEAP_OVERHEAD (-2)  /// Memory is used by malloc for internal accounting etc.


### PR DESCRIPTION
Gives us the ability to iterate over free areas and heap overhead areas too,
so we don't have to reconstruct them from the gaps in what is iterated.  Also
gives a dangerous option to iterate the heap without locking in order to prevent
deadlocks in crash handlers.