### PR TITLE
Ignore free

### DIFF
--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -373,8 +373,14 @@ void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_me
 void heap_caps_set_option(int option, void *value)
 {
     heap_t *heap;
-    SLIST_FOREACH(heap, &registered_heaps, next) {
-        multi_heap_set_option(heap->heap, option, value);
+    if (option == MALLOC_OPTION_THREAD_TAG) {
+      // For efficiency we don't do this on every heap, since the setting is
+      // per-thread, not per-heap.
+      multi_heap_set_option(NULL, option, value);
+    } else {
+      SLIST_FOREACH(heap, &registered_heaps, next) {
+          multi_heap_set_option(heap->heap, option, value);
+      }
     }
 }
 

--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -357,9 +357,9 @@ size_t heap_caps_get_minimum_free_size( uint32_t caps )
     return ret;
 }
 
-void heap_caps_set_thread_tag(void* tag)
+void heap_caps_set_thread_tag(void* value)
 {
-    multi_heap_set_thread_tag(tag);
+    multi_heap_set_option(NULL, MALLOC_OPTION_THREAD_TAG, value);
 }
 
 void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
@@ -367,6 +367,14 @@ void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_me
     heap_t *heap;
     SLIST_FOREACH(heap, &registered_heaps, next) {
         multi_heap_iterate_tagged_memory_areas(heap->heap, user_data, tag, callback, flags);
+    }
+}
+
+void heap_caps_set_option(int option, void *value)
+{
+    heap_t *heap;
+    SLIST_FOREACH(heap, &registered_heaps, next) {
+        multi_heap_set_option(heap->heap, option, value);
     }
 }
 

--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -357,11 +357,6 @@ size_t heap_caps_get_minimum_free_size( uint32_t caps )
     return ret;
 }
 
-void heap_caps_set_thread_tag(void* value)
-{
-    multi_heap_set_option(NULL, MALLOC_OPTION_THREAD_TAG, value);
-}
-
 void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
 {
     heap_t *heap;

--- a/components/heap/include/esp_heap_caps.h
+++ b/components/heap/include/esp_heap_caps.h
@@ -50,6 +50,12 @@ extern "C" {
 #define MALLOC_ITERATE_TAG_HEAP_OVERHEAD (-2)  /// Memory is used by malloc for internal accounting etc.
 
 /**
+ * Options for heap_caps_set_option
+ */
+#define MALLOC_OPTION_DISABLE_FREE 0 /// Value is false (null) or true (non-null).  Calls to free are ignored.
+#define MALLOC_OPTION_THREAD_TAG   1 /// The tag value to be attached to future allocations in this thread.
+
+/**
  * @brief Allocate a chunk of memory which has the given capabilities
  *
  * Equivalent semantics to libc malloc(), for capability-aware memory.
@@ -323,6 +329,9 @@ void heap_caps_dump_all();
 /**
  * @brief Set the tag value to be attached to future allocations in this thread.
  *
+ * This function is deprecated.  Use heap_caps_set_option with
+ * MALLOC_OPTION_THREAD_TAG instead.
+ *
  * @param tag         An opaque pointer that is attached to allocations.
  */
 void heap_caps_set_thread_tag(void *tag);
@@ -331,21 +340,29 @@ void heap_caps_set_thread_tag(void *tag);
  * @brief Iterate over allocations for this thread that have not yet been freed.
  *
  * Each allocation is created with a tag that comes from the last call to
- * heap_caps_set_thread_tag.  This function calls the callback for each
- * allocation that is not yet freed and has the given tag.  If the callback
- * returns true then the allocation is freed, otherwise it is preserved.  The
- * user_data argument is passed to the callback along with the tag and details
- * of the memory allocation.  If the tag is NULL then all allocations will be
- * iterated, but the callback can filter manually on the tag it is passed.
- * Note that the callback cannot allocate or deallocate, and this often means it
- * cannot call printf.
+ * heap_caps_set_option with the option MALLOC_OPTION_THREAD_TAG.  This
+ * function calls the callback for each allocation that is not yet freed and
+ * has the given tag.  If the callback returns true then the allocation is
+ * freed, otherwise it is preserved.  The user_data argument is passed to the
+ * callback along with the tag and details of the memory allocation.  If the
+ * tag is NULL then all allocations will be iterated, but the callback can
+ * filter manually on the tag it is passed.  Note that the callback cannot
+ * allocate or deallocate, and this often means it cannot call printf.
  *
  * @param user_data   A value that will be passed to each invocation of the callback.
- * @param tag         An opaque piece of data that was passed to heap_caps_set_thread_tag.
+ * @param tag         An opaque piece of data that was passed to heap_caps_set_option with the option MALLOC_OPTION_THREAD_TAG.
  * @param callback    A function to be called for each not-yet-freed memory area with the given tag.
  * @param flags       Zero or a set of flags, 'or'ed together from MALLOC_ITERATE_UNLOCKED, MALLOC_ITERATE_ALL_ALLOCATIONS and MALLOC_ITERATE_UNALLOCATED.
  */
 void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
+
+/**
+ * @brief Set global flags and options for the malloc heap.
+ *
+ * @param option  Select the option to set.  See MALLOC_OPTION_DISABLE_FREE etc.
+ * @param value   A value that depends on the option being set.
+ */
+void heap_caps_set_option(int option, void *value);
 
 #ifdef __cplusplus
 }

--- a/components/heap/include/esp_heap_caps.h
+++ b/components/heap/include/esp_heap_caps.h
@@ -327,16 +327,6 @@ void heap_caps_dump(uint32_t caps);
 void heap_caps_dump_all();
 
 /**
- * @brief Set the tag value to be attached to future allocations in this thread.
- *
- * This function is deprecated.  Use heap_caps_set_option with
- * MALLOC_OPTION_THREAD_TAG instead.
- *
- * @param tag         An opaque pointer that is attached to allocations.
- */
-void heap_caps_set_thread_tag(void *tag);
-
-/**
  * @brief Iterate over allocations for this thread that have not yet been freed.
  *
  * Each allocation is created with a tag that comes from the last call to

--- a/components/heap/include/multi_heap.h
+++ b/components/heap/include/multi_heap.h
@@ -176,7 +176,7 @@ void multi_heap_get_info(multi_heap_handle_t heap, multi_heap_info_t *info);
  */
 #define MULTI_HEAP_THREAD_TAG_INDEX 1
 
-void multi_heap_set_thread_tag(void *user_data);
+void multi_heap_set_option(multi_heap_handle_t heap, int option, void *value);
 void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
 
 #ifdef __cplusplus

--- a/components/heap/third_party/dartino/cmpctmalloc.c
+++ b/components/heap/third_party/dartino/cmpctmalloc.c
@@ -83,7 +83,7 @@ size_t multi_heap_minimum_free_size(cmpct_heap_t *heap)
 void multi_heap_iterate_tagged_memory_areas(cmpct_heap_t *heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
     __attribute__((alias("cmpct_iterate_tagged_memory_areas")));
 
-void multi_heap_set_option(cmpct_heap_t *heap, int option, void* value)
+void multi_heap_set_option(cmpct_heap_t *heap, int option, void *value)
     __attribute__((alias("cmpct_set_option")));
 
 typedef uintptr_t addr_t;
@@ -149,7 +149,7 @@ void *cmpct_alloc(cmpct_heap_t *heap, size_t size);
 void cmpct_free(cmpct_heap_t *heap, void *payload);
 size_t cmpct_free_size_impl(cmpct_heap_t *heap);
 size_t cmpct_get_allocated_size_impl(cmpct_heap_t *heap, void *p);
-void cmpct_set_option(cmpct_heap_t* heap, int option, void *value);
+void cmpct_set_option(cmpct_heap_t *heap, int option, void *value);
 static void *page_alloc(cmpct_heap_t *heap, intptr_t pages, void *tag);
 static void page_free(cmpct_heap_t *heap, void *address, int pages_dummy);
 struct header_struct;

--- a/components/heap/third_party/dartino/cmpctmalloc.c
+++ b/components/heap/third_party/dartino/cmpctmalloc.c
@@ -1549,9 +1549,4 @@ void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, heap_caps
     cmpct_iterate_tagged_memory_areas(heap, user_data, tag, callback, flags);
 }
 
-void heap_caps_set_thread_tag(void *user_data)
-{
-    cmpct_set_option(heap, MALLOC_OPTION_THREAD_TAG, user_data);
-}
-
 #endif


### PR DESCRIPTION
The idea is that on an OOM we can deactivate 'free' while closing down the VM.
Once we have closed down, we know there are no threads interfering with a heap
traversal.  At this point, we do a heap dump with everything still in place
from the OOM (because nothing was freed).  This is pretty experimental: It may not
work, if we can't do a heap dump because of a lack of memory, but then we will
reboot with a null pointer exception.

See also https://github.com/toitware/toit/pull/3137