### PR TITLE
Add a config file to control the Toit build

### DIFF
--- a/components/toit_config/Kconfig
+++ b/components/toit_config/Kconfig
@@ -1,0 +1,10 @@
+menu "Toit config"
+
+    config TOIT_BYTE_DISPLAY
+        bool "Include primitives for byte-oriented (true-color or 256-shade gray) displays"
+        default "y"
+
+    config TOIT_BIT_DISPLAY
+        bool "Include primitives for bit-oriented (2-color, 3-color, 4-shades) displays"
+        default "y"
+endmenu


### PR DESCRIPTION
I wasn't able to find any way to place this outside the third_party/esp-idf directory - suggestions welcome.

Once we roll to this version we can use #ifdef to remove bits of code in primitives etc. not needed on particular targets.