### PR TITLE
Add aligned allocation API to cmpctmalloc

### DIFF
--- a/components/heap/third_party/dartino/cmpctmalloc.h
+++ b/components/heap/third_party/dartino/cmpctmalloc.h
@@ -9,6 +9,8 @@ size_t cmpct_free_size_impl(multi_heap_handle_t heap);
 size_t cmpct_get_allocated_size_impl(multi_heap_handle_t heap, void *p);
 size_t cmpct_minimum_free_size_impl(multi_heap_handle_t heap);
 void cmpct_free_impl(multi_heap_handle_t heap, void *p);
+void *cmpct_aligned_alloc_impl(multi_heap_handle_t heap, size_t size, size_t alignment);
+void cmpct_aligned_free_impl(multi_heap_handle_t heap, void *p);
 void cmpct_get_info_impl(multi_heap_handle_t heap, multi_heap_info_t *info);
 void *cmpct_malloc_impl(multi_heap_handle_t heap, size_t size);
 void *cmpct_realloc_impl(multi_heap_handle_t heap, void *p, size_t size);


### PR DESCRIPTION
In the 4.1 release of esp-idf, the heap_caps allocation API has
grown the ability to ask for aligned allocation.  This change adds
the same abillity to cmpctmalloc.  We are on a branch of the 4.1
release branch which has our own patches already cherry-picked
from the 4.0 branch.