### PR TITLE
Don't print function name on failed asserts.

### DIFF
--- a/components/freertos/include/freertos/FreeRTOSConfig.h
+++ b/components/freertos/include/freertos/FreeRTOSConfig.h
@@ -123,13 +123,11 @@ int xt_clock_freq(void) __attribute__((deprecated));
 #define configASSERT(a) /* assertions disabled */
 #elif defined(CONFIG_FREERTOS_ASSERT_FAIL_PRINT_CONTINUE)
 #define configASSERT(a) if (!(a)) {                                     \
-        ets_printf("%s:%d (%s)- assert failed!\n", __FILE__, __LINE__,  \
-                   __FUNCTION__);                                       \
+        ets_printf("%s:%d assert failed!\n", __FILE__, __LINE__);       \
     }
 #else /* CONFIG_FREERTOS_ASSERT_FAIL_ABORT */
 #define configASSERT(a) if (!(a)) {                                     \
-        ets_printf("%s:%d (%s)- assert failed!\n", __FILE__, __LINE__,  \
-                   __FUNCTION__);                                       \
+        ets_printf("%s:%d (%s)- assert failed!\n", __FILE__, __LINE__); \
         abort();                                                        \
         }
 #endif


### PR DESCRIPTION
This just prints the file and line number, not the function
name, if an assert fails.  This saves 1232 bytes on our build.