### PR TITLE
Remove printf when LWIP API is abused.

### DIFF
--- a/components/lwip/port/esp32/include/arch/cc.h
+++ b/components/lwip/port/esp32/include/arch/cc.h
@@ -70,7 +70,8 @@ typedef int sys_prot_t;
 
 #include <stdio.h>
 
-#define LWIP_PLATFORM_DIAG(x)   do {printf x;} while(0)
+// Toitware: Removed the "printf x;" here to save space.
+#define LWIP_PLATFORM_DIAG(x)   do {} while(0)
 // __assert_func is the assertion failure handler from newlib, defined in assert.h
 #define LWIP_PLATFORM_ASSERT(message) __assert_func(__FILE__, __LINE__, __ASSERT_FUNC, message)
 


### PR DESCRIPTION
This saves about 4k in the binary size
by removing the string from places that
use the LWIP_ERROR macro in LwIP code.
They still handle the error, mostly by
returning an error code to the API caller.