### PR TITLE
Toitware's ESP-IDF fork uses a different lwip submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,7 +49,7 @@
 
 [submodule "components/lwip/lwip"]
 	path = components/lwip/lwip
-	url = ../../espressif/esp-lwip.git
+	url = ../../toitware/esp-lwip.git
 
 [submodule "components/mqtt/esp-mqtt"]
 	path = components/mqtt/esp-mqtt


### PR DESCRIPTION
Newer gits seem to be clever enough to find it even if the path isn't set correctly

Fixes https://github.com/toitlang/toit/issues/45