### PR TITLE
Make heap iteration selective with heap caps

### DIFF
--- a/components/heap/heap_caps.c
+++ b/components/heap/heap_caps.c
@@ -485,11 +485,11 @@ size_t heap_caps_get_minimum_free_size( uint32_t caps )
     return ret;
 }
 
-void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
+void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags, uint32_t caps)
 {
     heap_t *heap;
     SLIST_FOREACH(heap, &registered_heaps, next) {
-        if (heap->heap) {
+        if (heap_caps_match(heap, caps)) {
             multi_heap_iterate_tagged_memory_areas(heap->heap, user_data, tag, callback, flags);
         }
     }

--- a/components/heap/include/esp_heap_caps.h
+++ b/components/heap/include/esp_heap_caps.h
@@ -420,12 +420,20 @@ size_t heap_caps_get_allocated_size( void *ptr );
  * filter manually on the tag it is passed.  Note that the callback cannot
  * allocate or deallocate, and this often means it cannot call printf.
  *
- * @param user_data   A value that will be passed to each invocation of the callback.
- * @param tag         An opaque piece of data that was passed to heap_caps_set_option with the option MALLOC_OPTION_THREAD_TAG.
- * @param callback    A function to be called for each not-yet-freed memory area with the given tag.
- * @param flags       Zero or a set of flags, 'or'ed together from MALLOC_ITERATE_UNLOCKED, MALLOC_ITERATE_ALL_ALLOCATIONS and MALLOC_ITERATE_UNALLOCATED.
+ * @param user_data   A value that will be passed to each invocation of the
+ *                    callback.
+ * @param tag         An opaque piece of data that was passed to
+ *                    heap_caps_set_option with the option
+ *                    MALLOC_OPTION_THREAD_TAG.
+ * @param callback    A function to be called for each not-yet-freed memory
+ *                    area with the given tag.
+ * @param flags       Zero or a set of flags, 'or'ed together from
+ *                    MALLOC_ITERATE_UNLOCKED, MALLOC_ITERATE_ALL_ALLOCATIONS
+ *                    and MALLOC_ITERATE_UNALLOCATED.
+ * @param caps        Bitwise OR of MALLOC_CAP_* flags indicating the type of
+ *                    memory
  */
-void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
+void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags, uint32_t caps);
 
 /**
  * @brief Set global flags and options for the malloc heap.

--- a/components/heap/include/multi_heap.h
+++ b/components/heap/include/multi_heap.h
@@ -199,7 +199,7 @@ void multi_heap_get_info(multi_heap_handle_t heap, multi_heap_info_t *info);
 
 void multi_heap_set_option(multi_heap_handle_t heap, int option, void *value);
 void *multi_heap_get_option(int option);
-void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
+void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags);
 
 #ifdef __cplusplus
 }

--- a/components/heap/multi_heap.c
+++ b/components/heap/multi_heap.c
@@ -70,6 +70,20 @@ void *multi_heap_get_block_owner(multi_heap_block_handle_t block)
     return NULL;
 }
 
+void multi_heap_set_option(multi_heap_handle_t heap, int option, void *value)
+{
+}
+
+void *multi_heap_get_option(int option)
+{
+    return NULL;
+}
+
+void multi_heap_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags)
+{
+}
+
+
 #endif
 
 #define ALIGN(X) ((X) & ~(sizeof(void *)-1))

--- a/components/heap/third_party/dartino/cmpctmalloc.c
+++ b/components/heap/third_party/dartino/cmpctmalloc.c
@@ -90,7 +90,7 @@ size_t multi_heap_free_size(cmpct_heap_t *heap)
 size_t multi_heap_minimum_free_size(cmpct_heap_t *heap)
     __attribute__((alias("cmpct_minimum_free_size_impl")));
 
-void multi_heap_iterate_tagged_memory_areas(cmpct_heap_t *heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
+void multi_heap_iterate_tagged_memory_areas(cmpct_heap_t *heap, void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags)
     __attribute__((alias("cmpct_iterate_tagged_memory_areas")));
 
 void multi_heap_set_option(cmpct_heap_t *heap, int option, void *value)
@@ -1772,7 +1772,7 @@ void *cmpct_get_option(int option)
 #endif
 }
 
-void cmpct_iterate_tagged_memory_areas(cmpct_heap_t *heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags)
+void cmpct_iterate_tagged_memory_areas(cmpct_heap_t *heap, void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags)
 {
     if ((flags & CMPCTMALLOC_ITERATE_UNLOCKED) == 0) {
         lock(heap);
@@ -2022,7 +2022,7 @@ void *realloc(void *old, size_t size)
 }
 
 typedef bool heap_caps_iterate_callback(void *, void *, void *, size_t);
-void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, heap_caps_iterate_callback callback, int flags)
+void heap_caps_iterate_tagged_memory_areas(void *user_data, void *tag, heap_caps_iterate_callback callback, uint32_t flags, uint32_t caps)
 {
     cmpct_iterate_tagged_memory_areas(heap, user_data, tag, callback, flags);
 }

--- a/components/heap/third_party/dartino/cmpctmalloc.h
+++ b/components/heap/third_party/dartino/cmpctmalloc.h
@@ -12,7 +12,7 @@ void cmpct_free_impl(multi_heap_handle_t heap, void *p);
 void cmpct_get_info_impl(multi_heap_handle_t heap, multi_heap_info_t *info);
 void *cmpct_malloc_impl(multi_heap_handle_t heap, size_t size);
 void *cmpct_realloc_impl(multi_heap_handle_t heap, void *p, size_t size);
-void cmpct_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, int flags);
+void cmpct_iterate_tagged_memory_areas(multi_heap_handle_t heap, void *user_data, void *tag, tagged_memory_callback_t callback, uint32_t flags);
 
 // Flags for heap iteration.  Coordinate with constants in esp_heap_caps.h
 #define CMPCTMALLOC_ITERATE_UNLOCKED 1


### PR DESCRIPTION
This means we can make a heap report that excludes
IRAM, and PSRAM if it is not in use for the main
system allocation.

Also fixes compilation if you want to use the regular
esp-idf malloc instead of cmpctmalloc.