### PR TITLE
Remove 'static' on start_cpu0_default.

### DIFF
--- a/components/esp_system/startup.c
+++ b/components/esp_system/startup.c
@@ -417,7 +417,7 @@ static void do_secondary_init(void)
 #endif
 }
 
-static void start_cpu0_default(void)
+void start_cpu0_default(void)
 {
 
     ESP_EARLY_LOGI(TAG, "Pro cpu start user code");


### PR DESCRIPTION
This was introduced at some point, but it causes a linking error when trying to use the weak linking of start_cpu0 to run early init code as documented at https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/startup.html