### PR TITLE
cmpctmalloc: Protect MIN and MAX macros.

### DIFF
--- a/components/heap/third_party/dartino/cmpctmalloc.c
+++ b/components/heap/third_party/dartino/cmpctmalloc.c
@@ -145,8 +145,12 @@ static int first_allocations = true;
 #define ROUND_UP(x, alignment) (((x) + (alignment) - 1) & ~((alignment) - 1))
 #define ROUND_DOWN(x, alignment) ((x) & ~((alignment) - 1))
 #define IS_ALIGNED(x, alignment) (((x) & ((alignment) - 1)) == 0)
+#ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#endif
+#ifndef MAX
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+#endif
 // Provoke crash.  Often because of a double free.
 #define FATAL(reason) do { *(char *)(0xdeadf1ee) = 0; abort(); } while (0)
 #define INLINE __attribute__((always_inline)) inline

--- a/components/heap/third_party/dartino/cmpctmalloc.c
+++ b/components/heap/third_party/dartino/cmpctmalloc.c
@@ -145,12 +145,14 @@ static int first_allocations = true;
 #define ROUND_UP(x, alignment) (((x) + (alignment) - 1) & ~((alignment) - 1))
 #define ROUND_DOWN(x, alignment) ((x) & ~((alignment) - 1))
 #define IS_ALIGNED(x, alignment) (((x) & ((alignment) - 1)) == 0)
-#ifndef MIN
+#ifdef MIN
+#undef MIN
+#endif
+#ifdef MAX
+#undef MAX
+#endif
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
-#endif
-#ifndef MAX
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
-#endif
 // Provoke crash.  Often because of a double free.
 #define FATAL(reason) do { *(char *)(0xdeadf1ee) = 0; abort(); } while (0)
 #define INLINE __attribute__((always_inline)) inline


### PR DESCRIPTION
These are defined in
$HOME/.espressif/tools/riscv32-esp-elf/esp-2022r1-11.2.0/riscv32-esp-elf/riscv32-esp-elf/sys-include/sys/param.h causing a warning when defining them in cmpctmalloc.c.