### PR TITLE
fix(i2c): Add bus handle check so that it will not be panic when ther…

### DIFF
--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -744,7 +744,11 @@ static esp_err_t i2c_master_bus_destroy(i2c_master_bus_handle_t bus_handle)
 {
     ESP_RETURN_ON_FALSE(bus_handle, ESP_ERR_INVALID_ARG, TAG, "no memory for i2c master bus");
     i2c_master_bus_handle_t i2c_master = bus_handle;
-    if (i2c_release_bus_handle(i2c_master->base) == ESP_OK) {
+    esp_err_t err = ESP_OK;
+    if (i2c_master->base) {
+        err = i2c_release_bus_handle(i2c_master->base);
+    }
+    if (err == ESP_OK) {
         if (i2c_master) {
             if (i2c_master->bus_lock_mux) {
                 vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);


### PR DESCRIPTION
…e is no free bus,

Closes https://github.com/espressif/esp-idf/issues/14819

Cherry-pick of 0a098f49d4236ecff8b21cf7066fcf572847c454