### PR TITLE
Don't set a pull-up for RMT-RX.

### DIFF
--- a/components/esp_driver_rmt/src/rmt_rx.c
+++ b/components/esp_driver_rmt/src/rmt_rx.c
@@ -309,7 +309,6 @@ esp_err_t rmt_new_rx_channel(const rmt_rx_channel_config_t *config, rmt_channel_
     // GPIO Matrix/MUX configuration
     gpio_func_sel(config->gpio_num, PIN_FUNC_GPIO);
     gpio_input_enable(config->gpio_num);
-    gpio_pullup_en(config->gpio_num);
     esp_rom_gpio_connect_in_signal(config->gpio_num,
                                    rmt_periph_signals.groups[group_id].channels[channel_id + RMT_RX_CHANNEL_OFFSET_IN_GROUP].rx_sig,
                                    config->flags.invert_in);


### PR DESCRIPTION
This same change was applied to ESP-IDF master:
https://github.com/espressif/esp-idf/commit/c63f51dcb31bc0aadb5343e3c182c50244f1c41b