### PR TITLE
Set the initial value of the RMT-TX to 1 when in open-drain.

### DIFF
--- a/components/esp_driver_rmt/src/rmt_tx.c
+++ b/components/esp_driver_rmt/src/rmt_tx.c
@@ -348,7 +348,10 @@ esp_err_t rmt_new_tx_channel(const rmt_tx_channel_config_t *config, rmt_channel_
     // disable carrier modulation by default, can re-enable by `rmt_apply_carrier()`
     rmt_ll_tx_enable_carrier_modulation(hal->regs, channel_id, false);
     // idle level is determined by register value
-    rmt_ll_tx_fix_idle_level(hal->regs, channel_id, 0, true);
+    // Toit: work around https://github.com/espressif/esp-idf/issues/16068.
+    //   It should be possible to set the initial idle level, but to make things a bit easier, we
+    //   always set it to 1 for open-drain configurations. It's the safer and more useful option.
+    rmt_ll_tx_fix_idle_level(hal->regs, channel_id, config->flags.io_loop_back ? 1 : 0, true);
     // always enable tx wrap, both DMA mode and ping-pong mode rely this feature
     rmt_ll_tx_enable_wrap(hal->regs, channel_id, true);
 


### PR DESCRIPTION
This works around https://github.com/espressif/esp-idf/issues/16068. Once that issue is resolved we should adopt their solution.