### PR TITLE
Backport: fix(bt/bluedroid): fixed an OOB write in bta_dm_sdp_result [CVE-2025-68473]

### DIFF
--- a/components/bt/common/include/bt_common.h
+++ b/components/bt/common/include/bt_common.h
@@ -238,6 +238,7 @@ typedef uint64_t UINT64;
 typedef bool BOOLEAN;
 /* Maximum UUID size - 16 bytes, and structure to hold any type of UUID. */
 #define MAX_UUID_SIZE              16
+#define MAX_UUID_NUM               32
 
 typedef struct {
 #define LEN_UUID_16     2

--- a/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
+++ b/components/bt/host/bluedroid/bta/dm/bta_dm_act.c
@@ -2033,7 +2033,7 @@ void bta_dm_sdp_result (tBTA_DM_MSG *p_data)
 #endif
 
     UINT32 num_uuids = 0;
-    UINT8  uuid_list[32][MAX_UUID_SIZE]; // assuming a max of 32 services
+    UINT8  uuid_list[MAX_UUID_NUM][MAX_UUID_SIZE]; // assuming a max of MAX_UUID_NUM services
 
     if ((p_data->sdp_event.sdp_result == SDP_SUCCESS)
             || (p_data->sdp_event.sdp_result == SDP_NO_RECS_MATCH)
@@ -2096,8 +2096,12 @@ void bta_dm_sdp_result (tBTA_DM_MSG *p_data)
                             (tBTA_SERVICE_MASK)(BTA_SERVICE_ID_TO_SERVICE_MASK(bta_dm_search_cb.service_index - 1));
                         tmp_svc = bta_service_id_to_uuid_lkup_tbl[bta_dm_search_cb.service_index - 1];
                         /* Add to the list of UUIDs */
-                        sdpu_uuid16_to_uuid128(tmp_svc, uuid_list[num_uuids]);
-                        num_uuids++;
+                        if (num_uuids < MAX_UUID_NUM) {
+                            sdpu_uuid16_to_uuid128(tmp_svc, uuid_list[num_uuids]);
+                            num_uuids++;
+                        } else {
+                            APPL_TRACE_WARNING("only process the first %d records\n", MAX_UUID_NUM);
+                        }
                     }
                 }
             }
@@ -2131,8 +2135,13 @@ void bta_dm_sdp_result (tBTA_DM_MSG *p_data)
                 p_sdp_rec = SDP_FindServiceInDb_128bit(bta_dm_search_cb.p_sdp_db, p_sdp_rec);
                 if (p_sdp_rec) {
                     if (SDP_FindServiceUUIDInRec_128bit(p_sdp_rec, &temp_uuid)) {
-                        memcpy(uuid_list[num_uuids], temp_uuid.uu.uuid128, MAX_UUID_SIZE);
-                        num_uuids++;
+                        if (num_uuids < MAX_UUID_NUM) {
+                            memcpy(uuid_list[num_uuids], temp_uuid.uu.uuid128, MAX_UUID_SIZE);
+                            num_uuids++;
+                        } else {
+                            APPL_TRACE_WARNING("only process the first %d records\n", MAX_UUID_NUM);
+                            break;
+                        }
                     }
                 }
             } while (p_sdp_rec);


### PR DESCRIPTION
backports espressif/esp-idf 4d928f2265c3 (release/v5.3, 2025-10-28) for CVE-2025-68473 — OOB write in `bta_dm_sdp_result` when the number of SDP records exceeds the fixed `uuid_list[32]` array size. adds `MAX_UUID_NUM` define and bounds-checks before each write.

upstream commit: https://github.com/espressif/esp-idf/commit/4d928f2265c3
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-68473

diff: `bt_common.h + bta_dm_act.c | +15 -5`

haven't run the full esp-idf test suite locally.