### PR TITLE
Backport: fix(bt/bluedroid): fixed potential OOB in AVRCP vendor command composition [CVE-2025-68474]

### DIFF
--- a/components/bt/host/bluedroid/stack/avrc/avrc_opt.c
+++ b/components/bt/host/bluedroid/stack/avrc/avrc_opt.c
@@ -48,17 +48,28 @@
 ******************************************************************************/
 static BT_HDR   *avrc_vendor_msg(tAVRC_MSG_VENDOR *p_msg)
 {
-    BT_HDR  *p_cmd;
+    BT_HDR  *p_cmd = NULL;
     UINT8   *p_data;
 
-    assert(p_msg != NULL);
+/*
+  A vendor dependent command consists of at least of:
+  - A BT_HDR, plus
+  - AVCT_MSG_OFFSET, plus
+  - 3 bytes for ctype, subunit_type and op_vendor, plus
+  - 3 bytes for company_id
+*/
+#define AVRC_MIN_VENDOR_CMD_LEN (BT_HDR_SIZE + AVCT_MSG_OFFSET + AVRC_VENDOR_HDR_SIZE)
+
+    if (!p_msg) {
+        return NULL;
+    }
 
 #if AVRC_METADATA_INCLUDED == TRUE
-    assert(AVRC_META_CMD_BUF_SIZE > (AVRC_MIN_CMD_LEN + p_msg->vendor_len));
-    if ((p_cmd = (BT_HDR *) osi_malloc(AVRC_META_CMD_BUF_SIZE)) != NULL)
+    if ((AVRC_META_CMD_BUF_SIZE > AVRC_MIN_VENDOR_CMD_LEN + p_msg->vendor_len) &&
+        ((p_cmd = (BT_HDR *) osi_malloc(AVRC_META_CMD_BUF_SIZE)) != NULL))
 #else
-    assert(AVRC_CMD_BUF_SIZE > (AVRC_MIN_CMD_LEN + p_msg->vendor_len));
-    if ((p_cmd = (BT_HDR *) osi_malloc(AVRC_CMD_BUF_SIZE)) != NULL)
+    if ((AVRC_CMD_BUF_SIZE > (AVRC_MIN_VENDOR_CMD_LEN + p_msg->vendor_len)) &&
+        (p_cmd = (BT_HDR *) osi_malloc(AVRC_CMD_BUF_SIZE)) != NULL)
 #endif
     {
         p_cmd->offset   = AVCT_MSG_OFFSET;


### PR DESCRIPTION
backports espressif/esp-idf 0b0b59f2e19c (release/v5.3, 2025-10-09) for CVE-2025-68474 — replaces an `assert`-based bounds check (compiled out in release builds) with a runtime guard that returns NULL when the buffer can't hold the vendor command. adds `AVRC_MIN_VENDOR_CMD_LEN` define and NULL-check on `p_msg`.

upstream commit: https://github.com/espressif/esp-idf/commit/0b0b59f2e19c
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-68474

diff: `components/bt/host/bluedroid/stack/avrc/avrc_opt.c | +17 -6`

haven't run the full esp-idf test suite locally.