### PR TITLE
Backport: fix(protocomm): Add security checks for buffer overflow and incorrect length handling [CVE-2026-25507, CVE-2026-25508]

### DIFF
--- a/components/protocomm/src/transports/protocomm_nimble.c
+++ b/components/protocomm/src/transports/protocomm_nimble.c
@@ -5,6 +5,7 @@
  */
 
 #include <sys/param.h>
+#include <stdbool.h>
 #include <esp_log.h>
 #include <string.h>
 #include <inttypes.h>
@@ -73,6 +74,11 @@ typedef struct _protocomm_ble {
 } _protocomm_ble_internal_t;
 
 static _protocomm_ble_internal_t *protoble_internal;
+
+static bool protocomm_ble_transport_active(void)
+{
+    return (protoble_internal != NULL) && (protoble_internal->pc_ble != NULL);
+}
 static struct ble_gap_adv_params adv_params;
 static char *protocomm_ble_device_name;
 static struct ble_hs_adv_fields adv_data, resp_data;
@@ -285,6 +291,9 @@ simple_ble_gap_event(struct ble_gap_event *event, void *arg)
 /* Gets `g_nu_lookup name handler` from 128 bit UUID */
 static const char *uuid128_to_handler(uint8_t *uuid)
 {
+    if (!protocomm_ble_transport_active()) {
+        return NULL;
+    }
     /* Use it to convert 128 bit UUID to 16 bit UUID.*/
     uint8_t *uuid16 = uuid + 12;
     for (int i = 0; i < protoble_internal->g_nu_lookup_count; i++) {
@@ -303,6 +312,11 @@ static int
 gatt_svr_dsc_access(uint16_t conn_handle, uint16_t attr_handle, struct
                     ble_gatt_access_ctxt *ctxt, void *arg)
 {
+    if (!protocomm_ble_transport_active()) {
+        ESP_LOGW(TAG, "Ignoring descriptor access on inactive protocomm transport");
+        return BLE_ATT_ERR_UNLIKELY;
+    }
+
     if (ctxt->op != BLE_GATT_ACCESS_OP_READ_DSC) {
         ESP_LOGE(TAG, "Invalid operation on Read-only Descriptor");
         return BLE_ATT_ERR_UNLIKELY;
@@ -330,6 +344,11 @@ gatt_svr_chr_access(uint16_t conn_handle, uint16_t attr_handle,
     uint8_t *data_buf = NULL;
     uint16_t data_len = 0;
     uint16_t data_buf_len = 0;
+
+    if (!protocomm_ble_transport_active()) {
+        ESP_LOGW(TAG, "Ignoring characteristic access on inactive protocomm transport");
+        return BLE_ATT_ERR_UNLIKELY;
+    }
 
     switch (ctxt->op) {
     case BLE_GATT_ACCESS_OP_READ_CHR:
@@ -593,6 +612,11 @@ static void transport_simple_ble_disconnect(struct ble_gap_event *event, void *a
         return;
     }
 
+    if (!protocomm_ble_transport_active()) {
+        ESP_LOGD(TAG, "Protocomm BLE inactive, ignoring disconnect");
+        return;
+    }
+
     if (protoble_internal->pc_ble->sec &&
             protoble_internal->pc_ble->sec->close_transport_session) {
         ret =
@@ -626,6 +650,11 @@ static void transport_simple_ble_connect(struct ble_gap_event *event, void *arg)
         return;
     }
 
+    if (!protocomm_ble_transport_active()) {
+        ESP_LOGD(TAG, "Protocomm BLE inactive, ignoring connect");
+        return;
+    }
+
     if (protoble_internal->pc_ble->sec &&
             protoble_internal->pc_ble->sec->new_transport_session) {
         ret =
@@ -649,6 +678,9 @@ static void transport_simple_ble_connect(struct ble_gap_event *event, void *arg)
 
 static void transport_simple_ble_set_mtu(struct ble_gap_event *event, void *arg)
 {
+    if (!protocomm_ble_transport_active()) {
+        return;
+    }
     protoble_internal->gatt_mtu = event->mtu.value;
     return;
 }
@@ -1040,16 +1072,21 @@ esp_err_t protocomm_ble_start(protocomm_t *pc, const protocomm_ble_config_t *con
 esp_err_t protocomm_ble_stop(protocomm_t *pc)
 {
     ESP_LOGD(TAG, "protocomm_ble_stop called here...");
-    if ((pc != NULL) &&
-            (protoble_internal != NULL ) &&
-            (pc == protoble_internal->pc_ble)) {
-        esp_err_t ret = ESP_OK;
+    if ((pc == NULL) ||
+            (protoble_internal == NULL ) ||
+            (pc != protoble_internal->pc_ble)) {
+        return ESP_ERR_INVALID_ARG;
+    }
 
-        esp_err_t rc = ble_gap_adv_stop();
-        if (rc) {
-            ESP_LOGD(TAG, "Error in stopping advertisement with err code = %d",
-                     rc);
-        }
+    esp_err_t ret = ESP_OK;
+    bool ble_callbacks_active = true;
+    esp_err_t rc = ble_gap_adv_stop();
+    if (rc) {
+        ESP_LOGD(TAG, "Error in stopping advertisement with err code = %d",
+                 rc);
+    }
+
+    protoble_internal->pc_ble = NULL;
 
     if (ble_cfg_p->keep_ble_on) {
 #ifdef CONFIG_ESP_PROTOCOMM_DISCONNECT_AFTER_BLE_STOP
@@ -1059,6 +1096,9 @@ esp_err_t protocomm_ble_stop(protocomm_t *pc)
            ESP_LOGI(TAG, "Error in terminating connection rc = %d",rc);
        }
        free_gatt_ble_misc_memory(ble_cfg_p);
+       ble_callbacks_active = false;
+#else
+       ESP_LOGD(TAG, "Keeping BLE stack running after protocomm stop");
 #endif // CONFIG_ESP_PROTOCOMM_DISCONNECT_AFTER_BLE_STOP
     }
     else {
@@ -1068,10 +1108,11 @@ esp_err_t protocomm_ble_stop(protocomm_t *pc)
             nimble_port_deinit();
         }
         free_gatt_ble_misc_memory(ble_cfg_p);
+        ble_callbacks_active = false;
     }
 
+    if (!ble_callbacks_active) {
         protocomm_ble_cleanup();
-        return ret;
     }
-    return ESP_ERR_INVALID_ARG;
+    return ret;
 }


### PR DESCRIPTION
backports espressif/esp-idf 0540c85140c2 (release/v5.5, 2025-12-02) for CVE-2026-25507 and CVE-2026-25508 — buffer overflow and incorrect length handling in protocomm BLE/NimBLE transports.

both CVE IDs reference the same fix shape on two upstream release branches:
- release/v5.5 commit `0540c85140c2` = CVE-2026-25508
- release/v6.0 commit `1ff264abf250` = CVE-2026-25507

identical patch-id confirmed between the two upstream commits.

upstream commit: https://github.com/espressif/esp-idf/commit/0540c85140c2
CVE 25507: https://nvd.nist.gov/vuln/detail/CVE-2026-25507
CVE 25508: https://nvd.nist.gov/vuln/detail/CVE-2026-25508

diff: `protocomm_ble.c + protocomm_nimble.c | +148 -23`

haven't run the full esp-idf test suite locally.