### PR TITLE
feat(i2c): add synchronous slave transmit provider

### DIFF
--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -409,7 +409,7 @@ static void s_i2c_start_end_command(i2c_master_bus_handle_t i2c_master, i2c_oper
 
         if (next_transaction.hw_cmd.op_code == I2C_LL_CMD_READ) {
 #if SOC_I2C_SUPPORT_10BIT_ADDR
-            if (i2c_master->addr_10bits_bus == I2C_ADDR_BIT_LEN_10) {
+            if (i2c_master->addr_10bits_bus == I2C_ADDR_BIT_LEN_10 && i2c_master->trans_idx == 0) {
                 i2c_ll_hw_cmd_t hw_write_cmd = {
                     .ack_en = false,
                     .op_code = I2C_LL_CMD_WRITE,
@@ -436,7 +436,7 @@ static void s_i2c_start_end_command(i2c_master_bus_handle_t i2c_master, i2c_oper
                 .byte_num = 1,
             };
             portENTER_CRITICAL_SAFE(&i2c_master->base->spinlock);
-            i2c_ll_write_txfifo(hal->dev, addr_read, sizeof(addr_read));
+            i2c_ll_write_txfifo(hal->dev, addr_read, 1);
             i2c_ll_master_write_cmd_reg(hal->dev, hw_write_cmd, i2c_master->cmd_idx);
             i2c_master->cmd_idx++;
             portEXIT_CRITICAL_SAFE(&i2c_master->base->spinlock);

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -225,6 +225,7 @@ struct i2c_slave_dev_t {
     i2c_slave_receive_t receive_desc;                 // slave receive descriptor
     bool receive_overflow;                            // bytes were dropped in the current receive transaction
     bool request_pending;                             // target is stretching at a read address match
+    bool transmit_active;                             // controller is reading from the target
 };
 
 #endif // CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -215,10 +215,13 @@ struct i2c_slave_dev_t {
     SemaphoreHandle_t operation_mux;                  // Mux for i2c slave task writers
     i2c_slave_request_callback_t request_callback;    // i2c slave request callback
     i2c_slave_received_callback_t receive_callback;   // i2c_slave receive callback
+    i2c_slave_transmit_callback_t transmit_callback;  // synchronously provide transmit data from the ISR
+    i2c_slave_transmit_done_callback_t transmit_done_callback; // synchronously provided transmit data completed
     void *user_ctx;                                   // Callback user context
     RingbufHandle_t rx_ring_buf;                      // receive ringbuffer
     RingbufHandle_t tx_ring_buf;                      // transmit ringbuffer
     uint32_t rx_data_count;                           // receive data count
+    uint32_t tx_data_count;                           // callback-provided bytes loaded for the current transaction
     i2c_slave_receive_t receive_desc;                 // slave receive descriptor
     bool receive_overflow;                            // bytes were dropped in the current receive transaction
     bool request_pending;                             // target is stretching at a read address match

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -70,6 +70,26 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     uint32_t fifo_len = 0;
     portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
     i2c_ll_get_txfifo_len(hal->dev, &fifo_len);
+    while (i2c_slave->transmit_callback && fifo_len > 0) {
+        i2c_slave_transmit_event_data_t edata = {
+            .buffer = NULL,
+            .buffer_size = fifo_len,
+            .length = 0,
+        };
+        xTaskWoken |= i2c_slave->transmit_callback(i2c_slave, &edata, i2c_slave->user_ctx);
+        size_t callback_length = edata.length < fifo_len ? edata.length : fifo_len;
+        if (edata.buffer == NULL || callback_length == 0) {
+            break;
+        }
+        portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        i2c_ll_write_txfifo(hal->dev, edata.buffer, callback_length);
+        i2c_slave->tx_data_count += callback_length;
+        fifo_len -= callback_length;
+        if (loaded) {
+            *loaded += callback_length;
+        }
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    }
     size_t actual_get_len = 0;
     while (fifo_len > 0) {
         data = xRingbufferReceiveUpToFromISR(i2c_slave->tx_ring_buf, &actual_get_len, fifo_len);
@@ -89,6 +109,41 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
     return xTaskWoken;
 }
+
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+IRAM_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
+{
+    if (!i2c_slave->transmit_callback) {
+        return false;
+    }
+
+    BaseType_t xTaskWoken = pdFALSE;
+    i2c_hal_context_t *hal = &i2c_slave->base->hal;
+    uint32_t free_fifo_len = 0;
+    portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    i2c_ll_slave_disable_tx_it(hal->dev);
+    i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
+    uint32_t remaining = SOC_I2C_FIFO_LEN - free_fifo_len;
+    uint32_t removed = i2c_slave->tx_data_count > remaining
+        ? i2c_slave->tx_data_count - remaining
+        : 0;
+    // The slave peripheral removes the next byte from the FIFO before it sees
+    // the controller's terminal NACK. That prefetched byte was not clocked as
+    // part of the completed transaction.
+    uint32_t transmitted = removed > 0 ? removed - 1 : 0;
+    i2c_slave->tx_data_count = 0;
+    i2c_ll_txfifo_rst(hal->dev);
+    portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+
+    if (i2c_slave->transmit_done_callback) {
+        i2c_slave_transmit_done_event_data_t edata = {
+            .length = transmitted,
+        };
+        xTaskWoken |= i2c_slave->transmit_done_callback(i2c_slave, &edata, i2c_slave->user_ctx);
+    }
+    return xTaskWoken;
+}
+#endif
 
 IRAM_ATTR static bool i2c_slave_handle_rx_fifo(i2c_slave_dev_t *i2c_slave, uint32_t len)
 {
@@ -197,12 +252,19 @@ IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
     uint32_t rx_fifo_exist_len = 0;
     i2c_ll_get_rxfifo_cnt(hal->dev, &rx_fifo_exist_len);
     i2c_slave_read_write_status_t slave_rw = i2c_ll_slave_get_read_write_status(hal->dev);
+    bool transmit_done = false;
 
     if (int_mask & I2C_INTR_SLV_RXFIFO_WM) {
         pxHigherPriorityTaskWoken |= i2c_slave_handle_rx_fifo(i2c_slave, rx_fifo_exist_len);
     }
 
     if (int_mask & I2C_INTR_SLV_COMPLETE) {
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+        if (slave_rw == I2C_SLAVE_READ_BY_MASTER) {
+            pxHigherPriorityTaskWoken |= i2c_slave_handle_tx_done(i2c_slave);
+            transmit_done = i2c_slave->transmit_callback != NULL;
+        }
+#endif
         if (rx_fifo_exist_len) {
             pxHigherPriorityTaskWoken |= i2c_slave_handle_rx_fifo(i2c_slave, rx_fifo_exist_len);
         }
@@ -236,7 +298,7 @@ IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
     }
 #endif
 
-    if (int_mask & I2C_INTR_SLV_TXFIFO_WM) {  // TX FiFo Empty
+    if ((int_mask & I2C_INTR_SLV_TXFIFO_WM) && !transmit_done) {  // TX FiFo Empty
         pxHigherPriorityTaskWoken |= i2c_slave_handle_tx_fifo(i2c_slave, NULL);
     }
 
@@ -394,6 +456,7 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     ESP_RETURN_ON_FALSE(i2c_slave, ESP_ERR_INVALID_ARG, TAG, "i2c slave not initialized");
     ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "invalid data buffer");
     ESP_RETURN_ON_FALSE(write_len, ESP_ERR_INVALID_ARG, TAG, "invalid write length pointer");
+    ESP_RETURN_ON_FALSE(!i2c_slave->transmit_callback, ESP_ERR_INVALID_STATE, TAG, "transmit callback is registered");
     uint32_t free_fifo_len = 0;
     uint32_t write_ringbuffer_len = 0;
     uint32_t actual_write_fifo_size = 0;
@@ -485,12 +548,21 @@ esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, c
 {
     ESP_RETURN_ON_FALSE(i2c_slave != NULL, ESP_ERR_INVALID_ARG, TAG, "i2c slave handle not initialized");
     ESP_RETURN_ON_FALSE(cbs, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
+#if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+    ESP_RETURN_ON_FALSE(!cbs->on_transmit && !cbs->on_transmit_done, ESP_ERR_NOT_SUPPORTED, TAG, "synchronous transmit callbacks are not supported");
+#endif
 #if CONFIG_I2C_ISR_IRAM_SAFE
     if (cbs->on_request) {
-        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_request), ESP_ERR_INVALID_ARG, TAG, "i2c request occur callback not in IRAM");
+        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_request) || esp_ptr_in_rtc_iram_fast(cbs->on_request), ESP_ERR_INVALID_ARG, TAG, "i2c request occur callback not in IRAM");
     }
     if (cbs->on_receive) {
-        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_receive), ESP_ERR_INVALID_ARG, TAG, "i2c receive occur callback not in IRAM");
+        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_receive) || esp_ptr_in_rtc_iram_fast(cbs->on_receive), ESP_ERR_INVALID_ARG, TAG, "i2c receive occur callback not in IRAM");
+    }
+    if (cbs->on_transmit) {
+        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_transmit) || esp_ptr_in_rtc_iram_fast(cbs->on_transmit), ESP_ERR_INVALID_ARG, TAG, "i2c transmit callback not in IRAM");
+    }
+    if (cbs->on_transmit_done) {
+        ESP_RETURN_ON_FALSE(esp_ptr_in_iram(cbs->on_transmit_done) || esp_ptr_in_rtc_iram_fast(cbs->on_transmit_done), ESP_ERR_INVALID_ARG, TAG, "i2c transmit done callback not in IRAM");
     }
     if (user_data) {
         ESP_RETURN_ON_FALSE(esp_ptr_internal(user_data), ESP_ERR_INVALID_ARG, TAG, "user context not in internal RAM");
@@ -500,5 +572,7 @@ esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, c
     i2c_slave->user_ctx = user_data;
     i2c_slave->request_callback = cbs->on_request;
     i2c_slave->receive_callback = cbs->on_receive;
+    i2c_slave->transmit_callback = cbs->on_transmit;
+    i2c_slave->transmit_done_callback = cbs->on_transmit_done;
     return ESP_OK;
 }

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -68,15 +68,20 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
     uint8_t *data;
     uint32_t fifo_len = 0;
+    i2c_slave_transmit_callback_t transmit_callback;
+    void *user_ctx;
     portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
     i2c_ll_get_txfifo_len(hal->dev, &fifo_len);
-    while (i2c_slave->transmit_callback && fifo_len > 0) {
+    transmit_callback = i2c_slave->transmit_callback;
+    user_ctx = i2c_slave->user_ctx;
+    portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    while (transmit_callback && fifo_len > 0) {
         i2c_slave_transmit_event_data_t edata = {
             .buffer = NULL,
             .buffer_size = fifo_len,
             .length = 0,
         };
-        xTaskWoken |= i2c_slave->transmit_callback(i2c_slave, &edata, i2c_slave->user_ctx);
+        xTaskWoken |= transmit_callback(i2c_slave, &edata, user_ctx);
         size_t callback_length = edata.length < fifo_len ? edata.length : fifo_len;
         if (edata.buffer == NULL || callback_length == 0) {
             break;
@@ -90,6 +95,14 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
         }
         portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
     }
+
+    // Callback-backed and buffered writes are separate transmit modes. In
+    // callback mode there must not be any buffered data to mix into the FIFO.
+    if (transmit_callback) {
+        return xTaskWoken;
+    }
+
+    portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
     size_t actual_get_len = 0;
     while (fifo_len > 0) {
         data = xRingbufferReceiveUpToFromISR(i2c_slave->tx_ring_buf, &actual_get_len, fifo_len);
@@ -125,8 +138,8 @@ IRAM_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
     i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
     uint32_t remaining = SOC_I2C_FIFO_LEN - free_fifo_len;
     uint32_t removed = i2c_slave->tx_data_count > remaining
-        ? i2c_slave->tx_data_count - remaining
-        : 0;
+                       ? i2c_slave->tx_data_count - remaining
+                       : 0;
     // The slave peripheral removes the next byte from the FIFO before it sees
     // the controller's terminal NACK. That prefetched byte was not clocked as
     // part of the completed transaction.
@@ -185,7 +198,7 @@ static size_t i2c_slave_fill_tx_fifo(i2c_slave_dev_t *i2c_slave, size_t fifo_len
 }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
-IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave, uint32_t rx_fifo_exist_len)
+IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave, uint32_t rx_fifo_exist_len, i2c_slave_read_write_status_t slave_rw)
 {
     i2c_slave_stretch_cause_t cause;
     BaseType_t xTaskWoken = pdFALSE;
@@ -194,6 +207,7 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
     if (cause == I2C_SLAVE_STRETCH_CAUSE_ADDRESS_MATCH) {
         portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
         i2c_slave->request_pending = true;
+        i2c_slave->transmit_active = slave_rw == I2C_SLAVE_READ_BY_MASTER;
         portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
         if (rx_fifo_exist_len) {
             xTaskWoken |= i2c_slave_handle_rx_fifo(i2c_slave, rx_fifo_exist_len);
@@ -290,11 +304,18 @@ IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
             }
 #endif
         }
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+        if (slave_rw == I2C_SLAVE_READ_BY_MASTER) {
+            portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_slave->transmit_active = false;
+            portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        }
+#endif
     }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
     if (int_mask & I2C_INTR_STRETCH) {  // STRETCH
-        pxHigherPriorityTaskWoken |= i2c_slave_handle_stretch_event(i2c_slave, rx_fifo_exist_len);
+        pxHigherPriorityTaskWoken |= i2c_slave_handle_stretch_event(i2c_slave, rx_fifo_exist_len, slave_rw);
     }
 #endif
 
@@ -456,7 +477,6 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     ESP_RETURN_ON_FALSE(i2c_slave, ESP_ERR_INVALID_ARG, TAG, "i2c slave not initialized");
     ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "invalid data buffer");
     ESP_RETURN_ON_FALSE(write_len, ESP_ERR_INVALID_ARG, TAG, "invalid write length pointer");
-    ESP_RETURN_ON_FALSE(!i2c_slave->transmit_callback, ESP_ERR_INVALID_STATE, TAG, "transmit callback is registered");
     uint32_t free_fifo_len = 0;
     uint32_t write_ringbuffer_len = 0;
     uint32_t actual_write_fifo_size = 0;
@@ -470,6 +490,12 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     }
 
     portENTER_CRITICAL(&i2c_slave->base->spinlock);
+    if (i2c_slave->transmit_callback) {
+        portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+        xSemaphoreGive(i2c_slave->operation_mux);
+        ESP_LOGE(TAG, "transmit callback is registered");
+        return ESP_ERR_INVALID_STATE;
+    }
 #if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
     i2c_ll_slave_disable_tx_it(hal->dev);
     uint32_t txfifo_len = 0;
@@ -569,10 +595,34 @@ esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, c
     }
 #endif
 
-    i2c_slave->user_ctx = user_data;
-    i2c_slave->request_callback = cbs->on_request;
-    i2c_slave->receive_callback = cbs->on_receive;
-    i2c_slave->transmit_callback = cbs->on_transmit;
-    i2c_slave->transmit_done_callback = cbs->on_transmit_done;
-    return ESP_OK;
+    // Keep callback-backed and buffered transmit data from sharing the FIFO.
+    // Take the writer mutex without waiting so this API remains non-blocking.
+    ESP_RETURN_ON_FALSE(xSemaphoreTake(i2c_slave->operation_mux, 0) == pdTRUE, ESP_ERR_TIMEOUT, TAG, "another operation is in progress");
+    esp_err_t ret = ESP_OK;
+    portENTER_CRITICAL(&i2c_slave->base->spinlock);
+    if (i2c_slave->transmit_active) {
+        ret = ESP_ERR_INVALID_STATE;
+    } else if (i2c_slave->transmit_callback != cbs->on_transmit) {
+        UBaseType_t buffered_bytes = 0;
+        uint32_t free_fifo_len = 0;
+        vRingbufferGetInfo(i2c_slave->tx_ring_buf, NULL, NULL, NULL, NULL, &buffered_bytes);
+        i2c_ll_get_txfifo_len(i2c_slave->base->hal.dev, &free_fifo_len);
+        if (i2c_slave->tx_data_count != 0 || buffered_bytes != 0 ||
+                free_fifo_len != SOC_I2C_FIFO_LEN) {
+            ret = ESP_ERR_INVALID_STATE;
+        }
+    }
+
+    if (ret == ESP_OK) {
+        i2c_slave->user_ctx = user_data;
+        i2c_slave->request_callback = cbs->on_request;
+        i2c_slave->receive_callback = cbs->on_receive;
+        i2c_slave->transmit_callback = cbs->on_transmit;
+        i2c_slave->transmit_done_callback = cbs->on_transmit_done;
+    }
+    portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+    xSemaphoreGive(i2c_slave->operation_mux);
+
+    ESP_RETURN_ON_ERROR(ret, TAG, "cannot change transmit mode while data is pending");
+    return ret;
 }

--- a/components/esp_driver_i2c/include/driver/i2c_slave.h
+++ b/components/esp_driver_i2c/include/driver/i2c_slave.h
@@ -167,6 +167,8 @@ typedef struct {
 typedef struct {
     i2c_slave_request_callback_t on_request;         /*!< Callback for when a master requests data from the slave */
     i2c_slave_received_callback_t on_receive;         /*!< Callback for when the slave receives data from the master */
+    i2c_slave_transmit_callback_t on_transmit;        /*!< Callback to synchronously provide requested data from ISR context */
+    i2c_slave_transmit_done_callback_t on_transmit_done; /*!< Callback reporting how many synchronously provided bytes were transmitted */
 } i2c_slave_event_callbacks_t;
 
 /**

--- a/components/esp_driver_i2c/include/driver/i2c_slave.h
+++ b/components/esp_driver_i2c/include/driver/i2c_slave.h
@@ -213,6 +213,8 @@ esp_err_t i2c_new_slave_device(const i2c_slave_config_t *slave_config, i2c_slave
  * @return
  *      - ESP_OK: Set I2C transaction callbacks successfully
  *      - ESP_ERR_INVALID_ARG: Set I2C transaction callbacks failed because of invalid argument
+ *      - ESP_ERR_INVALID_STATE: Transmit mode cannot be changed while a transaction or buffered data is pending
+ *      - ESP_ERR_TIMEOUT: Another operation is in progress
  *      - ESP_FAIL: Set I2C transaction callbacks failed because of other error
  */
 esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, const i2c_slave_event_callbacks_t *cbs, void *user_data);

--- a/components/esp_driver_i2c/include/driver/i2c_types.h
+++ b/components/esp_driver_i2c/include/driver/i2c_types.h
@@ -164,6 +164,37 @@ typedef struct {
  */
 typedef bool (*i2c_slave_request_callback_t)(i2c_slave_dev_handle_t i2c_slave, const i2c_slave_request_event_data_t *evt_data, void *arg);
 
+/**
+ * @brief Event structure used to synchronously provide target transmit data.
+ */
+typedef struct {
+    const uint8_t *buffer; /**< Internal-memory buffer supplied by the callback. */
+    uint32_t buffer_size;  /**< Maximum number of bytes requested. */
+    uint32_t length;       /**< Number of bytes supplied by the callback. */
+} i2c_slave_transmit_event_data_t;
+
+/**
+ * @brief ISR callback for synchronously providing data requested by a controller.
+ *
+ * The callback must set `buffer` to data in internal memory that remains valid
+ * until the transaction completes, and set `length` to at most `buffer_size`.
+ * It can be called repeatedly during one transaction. Registering this callback
+ * makes `i2c_slave_write` unavailable.
+ */
+typedef bool (*i2c_slave_transmit_callback_t)(i2c_slave_dev_handle_t i2c_slave, i2c_slave_transmit_event_data_t *evt_data, void *arg);
+
+/**
+ * @brief Event structure used when a controller read transaction completes.
+ */
+typedef struct {
+    uint32_t length;  /**< Number of callback-provided bytes clocked by the controller. */
+} i2c_slave_transmit_done_event_data_t;
+
+/**
+ * @brief ISR callback for completion of a controller read transaction.
+ */
+typedef bool (*i2c_slave_transmit_done_callback_t)(i2c_slave_dev_handle_t i2c_slave, const i2c_slave_transmit_done_event_data_t *evt_data, void *arg);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

- Correct the 10-bit controller read address sequence.
- Add an ISR-context transmit provider to the I2C target-v2 callbacks, allowing a fixed register map to provide bytes without waiting for an application task.
- Report the transmitted byte count after the transaction so the provider can advance register state safely.

## Dependencies

- Builds on #121.
- Required by toitlang/toit#3155.

## Testing

Exercised by Toit's autonomous register-target hardware suite on ESP32 and ESP32-S3, including 7-bit/10-bit addressing, register wrapping, updates, and oversized writes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
