### PR TITLE
fix(spi): correct target mode and bit-order handling

### DIFF
--- a/components/esp_driver_spi/src/gpspi/spi_slave.c
+++ b/components/esp_driver_spi/src/gpspi/spi_slave.c
@@ -266,8 +266,15 @@ esp_err_t spi_slave_initialize(spi_host_device_t host, const spi_bus_config_t *b
     };
     spi_slave_hal_init(hal, &hal_config);
 
+#if CONFIG_IDF_TARGET_ESP32
+    // On the classic ESP32, the LL read/write names describe the peripheral
+    // data registers. They are opposite to the target-facing RX/TX directions.
+    hal->rx_lsbfirst = (slave_config->flags & SPI_SLAVE_TXBIT_LSBFIRST) ? 1 : 0;
+    hal->tx_lsbfirst = (slave_config->flags & SPI_SLAVE_RXBIT_LSBFIRST) ? 1 : 0;
+#else
     hal->rx_lsbfirst = (slave_config->flags & SPI_SLAVE_RXBIT_LSBFIRST) ? 1 : 0;
     hal->tx_lsbfirst = (slave_config->flags & SPI_SLAVE_TXBIT_LSBFIRST) ? 1 : 0;
+#endif
     hal->mode = slave_config->mode;
     hal->use_dma = spihost[host]->dma_enabled;
     spi_slave_hal_setup_device(hal);

--- a/components/hal/esp32/include/hal/spi_ll.h
+++ b/components/hal/esp32/include/hal/spi_ll.h
@@ -466,8 +466,11 @@ static inline void spi_ll_slave_set_mode(spi_dev_t *hw, const int mode, bool dma
         hw->ctrl2.mosi_delay_mode = 2;
         hw->ctrl2.mosi_delay_num = 2;
     } else if (mode == 1) {
-        hw->pin.ck_idle_edge = 1;
-        hw->user.ck_i_edge = 1;
+        // Without DMA, select the MOSI latch edge. The original settings
+        // sample at the controller's launch edge (IDFGH-6011). Keep the old
+        // DMA settings because the classic ESP32 DMA engine depends on them.
+        hw->pin.ck_idle_edge = dma_used ? 1 : 0;
+        hw->user.ck_i_edge = dma_used ? 1 : 0;
         hw->ctrl2.miso_delay_mode = 2;
         hw->ctrl2.miso_delay_num = 0;
         hw->ctrl2.mosi_delay_mode = 0;
@@ -481,8 +484,11 @@ static inline void spi_ll_slave_set_mode(spi_dev_t *hw, const int mode, bool dma
         hw->ctrl2.mosi_delay_mode = 1;
         hw->ctrl2.mosi_delay_num = 2;
     } else if (mode == 3) {
-        hw->pin.ck_idle_edge = 0;
-        hw->user.ck_i_edge = 0;
+        // Without DMA, select the MOSI latch edge. The original settings
+        // sample at the controller's launch edge (IDFGH-6011). Keep the old
+        // DMA settings because the classic ESP32 DMA engine depends on them.
+        hw->pin.ck_idle_edge = dma_used ? 0 : 1;
+        hw->user.ck_i_edge = dma_used ? 0 : 1;
         hw->ctrl2.miso_delay_mode = 1;
         hw->ctrl2.miso_delay_num = 0;
         hw->ctrl2.mosi_delay_mode = 0;

--- a/components/hal/esp32s3/include/hal/spi_ll.h
+++ b/components/hal/esp32s3/include/hal/spi_ll.h
@@ -608,8 +608,10 @@ static inline void spi_ll_slave_set_mode(spi_dev_t *hw, const int mode, bool dma
         hw->slave.clk_mode_13 = 1;
     } else if (mode == 2) {
         hw->misc.ck_idle_edge = 1;
-        hw->user.rsck_i_edge = 1;
-        hw->user.tsck_i_edge = 1;
+        // DMA needs the opposite internal edge to keep RX aligned with the
+        // non-DMA path and to advance each TX bit before the sampling edge.
+        hw->user.rsck_i_edge = dma_used ? 0 : 1;
+        hw->user.tsck_i_edge = dma_used ? 0 : 1;
         hw->slave.clk_mode_13 = 0;
     } else if (mode == 3) {
         hw->misc.ck_idle_edge = 1;
@@ -617,7 +619,9 @@ static inline void spi_ll_slave_set_mode(spi_dev_t *hw, const int mode, bool dma
         hw->user.tsck_i_edge = 0;
         hw->slave.clk_mode_13 = 1;
     }
-    hw->slave.rsck_data_out = 0;
+    // In non-DMA mode 2, outputting on RSCK makes the first bit valid before
+    // the controller's leading edge. DMA uses the edge selection above.
+    hw->slave.rsck_data_out = mode == 2 && !dma_used;
 }
 
 /**


### PR DESCRIPTION
Stacked on #123.

This fixes target-mode issues found while bringing up asynchronous SPI target support in Toit:

- Map the public target-facing TX/RX LSB-first flags to the corresponding peripheral register directions. Classic ESP32 has the opposite internal naming; newer chips use the target-facing direction directly.
- On classic ESP32 without DMA, select the correct MOSI sampling edge in modes 1 and 3. Keep the existing DMA settings because that DMA engine depends on them.
- On ESP32-S3 in mode 2, select separate DMA/non-DMA internal edges and make the first non-DMA output bit valid before the leading controller edge.

Validated with exhaustive two-device hardware tests on both classic ESP32 and ESP32-S3: modes 0 through 3, independent RX/TX bit order, supported DMA and non-DMA direction combinations, 50 kHz through 2 MHz, early termination, one-way transfers, and sizes through 4092 bytes. The classic mode 1/3 issue corresponds to Espressif IDFGH-6011.