### PR TITLE
spi: add non-blocking bus acquisition

### DIFF
--- a/components/esp_driver_spi/include/driver/spi_master.h
+++ b/components/esp_driver_spi/include/driver/spi_master.h
@@ -338,6 +338,21 @@ esp_err_t spi_device_polling_transmit(spi_device_handle_t handle, spi_transactio
 esp_err_t spi_device_acquire_bus(spi_device_handle_t device, TickType_t wait);
 
 /**
+ * @brief Try to occupy the SPI bus for a device without waiting.
+ *
+ * On success this has the same effect as `spi_device_acquire_bus`. The caller
+ * must eventually call `spi_device_release_bus`.
+ *
+ * @param device The device requesting exclusive use of the bus.
+ *
+ * @return
+ *      - ESP_ERR_TIMEOUT : The bus is currently in use
+ *      - ESP_ERR_INVALID_STATE : A polling transaction is in progress
+ *      - ESP_OK : Success
+ */
+esp_err_t spi_device_try_acquire_bus(spi_device_handle_t device);
+
+/**
  * @brief Release the SPI bus occupied by the device. All other devices can start sending transactions.
  *
  * @param dev The device to release the bus.

--- a/components/esp_driver_spi/src/gpspi/spi_master.c
+++ b/components/esp_driver_spi/src/gpspi/spi_master.c
@@ -1305,13 +1305,14 @@ esp_err_t SPI_MASTER_ATTR spi_device_transmit(spi_device_handle_t handle, spi_tr
     return ESP_OK;
 }
 
-esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus(spi_device_t *device, TickType_t wait)
+static esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus_internal(spi_device_t *device, bool try_only, TickType_t wait)
 {
     spi_host_t *const host = device->host;
-    SPI_CHECK(wait == portMAX_DELAY, "acquire finite time not supported now.", ESP_ERR_INVALID_ARG);
     SPI_CHECK(!spi_bus_device_is_polling(device), "Cannot acquire bus when a polling transaction is in progress.", ESP_ERR_INVALID_STATE);
 
-    esp_err_t ret = spi_bus_lock_acquire_start(device->dev_lock, wait);
+    esp_err_t ret = try_only
+        ? spi_bus_lock_try_acquire_start(device->dev_lock)
+        : spi_bus_lock_acquire_start(device->dev_lock, wait);
     if (ret != ESP_OK) {
         return ret;
     }
@@ -1336,6 +1337,17 @@ esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus(spi_device_t *device, TickT
 #endif  //#if CONFIG_IDF_TARGET_ESP32
 
     return ESP_OK;
+}
+
+esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus(spi_device_t *device, TickType_t wait)
+{
+    SPI_CHECK(wait == portMAX_DELAY, "acquire finite time not supported now.", ESP_ERR_INVALID_ARG);
+    return spi_device_acquire_bus_internal(device, false, wait);
+}
+
+esp_err_t SPI_MASTER_ISR_ATTR spi_device_try_acquire_bus(spi_device_t *device)
+{
+    return spi_device_acquire_bus_internal(device, true, 0);
 }
 
 // This function restore configurations required in the non-polling mode

--- a/components/esp_hw_support/include/esp_private/spi_share_hw_ctrl.h
+++ b/components/esp_hw_support/include/esp_private/spi_share_hw_ctrl.h
@@ -337,6 +337,19 @@ bool spi_bus_lock_touch(spi_bus_lock_dev_handle_t dev_handle);
 esp_err_t spi_bus_lock_acquire_start(spi_bus_lock_dev_handle_t dev_handle, TickType_t wait);
 
 /**
+ * Try to acquire the SPI bus without waiting.
+ *
+ * Unlike `spi_bus_lock_acquire_start`, a failed attempt does not leave a
+ * pending acquisition request behind.
+ *
+ * @param dev_handle Handle to the device requesting the bus.
+ * @return
+ *  - ESP_OK: acquired
+ *  - ESP_ERR_TIMEOUT: the bus is currently in use
+ */
+esp_err_t spi_bus_lock_try_acquire_start(spi_bus_lock_dev_handle_t dev_handle);
+
+/**
  * Release the bus acquired. Will pass the acquiring processor to other blocked
  * processors (tasks or ISR), and cause them to be unblocked or invoked.
  *

--- a/components/esp_hw_support/spi_bus_lock.c
+++ b/components/esp_hw_support/spi_bus_lock.c
@@ -748,6 +748,38 @@ IRAM_ATTR esp_err_t spi_bus_lock_acquire_start(spi_bus_lock_dev_t *dev_handle, T
     return ESP_OK;
 }
 
+IRAM_ATTR esp_err_t spi_bus_lock_try_acquire_start(spi_bus_lock_dev_t *dev_handle)
+{
+    spi_bus_lock_t* lock = dev_handle->parent;
+
+    // A failed acquire_core call deliberately leaves the LOCK bit set so a
+    // blocking caller can be resumed later. A try operation must instead test,
+    // set, and roll that bit back under the scheduling critical section.
+    portENTER_CRITICAL_SAFE(&s_spinlock);
+    uint32_t own_lock = dev_handle->mask & LOCK_MASK;
+    uint32_t status = lock_status_fetch_set(lock, own_lock);
+    bool acquired = (status & (BG_MASK | LOCK_MASK)) == 0;
+    if (acquired) {
+        lock->acquiring_dev = dev_handle;
+        BUS_LOCK_DEBUG_EXECUTE_CHECK(!lock->acq_dev_bg_active);
+    } else if ((status & own_lock) == 0) {
+        // This call introduced the bit. Don't clear a pre-existing request or
+        // acquisition made concurrently through the same device handle.
+        lock_status_fetch_clear(lock, own_lock);
+    }
+    portEXIT_CRITICAL_SAFE(&s_spinlock);
+
+    if (!acquired) {
+        return ESP_ERR_TIMEOUT;
+    }
+    if (status & WEAK_BG_FLAG) {
+        bg_disable(lock);
+    }
+
+    ESP_DRAM_LOGV(TAG, "dev %d acquired without waiting.", dev_lock_get_id(dev_handle));
+    return ESP_OK;
+}
+
 IRAM_ATTR esp_err_t spi_bus_lock_acquire_end(spi_bus_lock_dev_t *dev_handle)
 {
     //release the bus


### PR DESCRIPTION
Adds an explicit non-blocking SPI bus-acquisition API for asynchronous runtimes. A failed try does not leave a pending lock request behind, while success has the same release contract as `spi_device_acquire_bus`.

This is needed by the stacked Toit asynchronous SPI controller change: primitives must never wait on an RTOS semaphore.

Validated through two-device Toit hardware tests on ESP32 and ESP32-S3, including repeated acquisition attempts while an interrupt-driven transaction owns the bus.

Stacked on #125.