### PR TITLE
fix(i2c, spi): handle target hardware edge cases

### DIFF
--- a/components/esp_driver_i2c/i2c_common.c
+++ b/components/esp_driver_i2c/i2c_common.c
@@ -189,15 +189,24 @@ esp_err_t i2c_acquire_bus_handle(i2c_port_num_t port_num, i2c_bus_handle_t *i2c_
 
 esp_err_t i2c_release_bus_handle(i2c_bus_handle_t i2c_bus)
 {
+    esp_err_t ret = ESP_OK;
     int port_num = i2c_bus->port_num;
     i2c_clock_source_t clk_src = i2c_bus->clk_src;
     bool do_deinitialize = false;
     _lock_acquire(&s_i2c_platform.mutex);
     if (s_i2c_platform.buses[port_num]) {
-        s_i2c_platform.count[port_num]--;
-        if (s_i2c_platform.count[port_num] == 0) {
+        if (s_i2c_platform.count[port_num] > 1) {
+            s_i2c_platform.count[port_num]--;
+        } else {
             do_deinitialize = true;
-            s_i2c_platform.buses[port_num] = NULL;
+            if (i2c_bus->intr_handle) {
+                ESP_GOTO_ON_ERROR(esp_intr_free(i2c_bus->intr_handle), err, TAG, "delete interrupt service failed");
+                i2c_bus->intr_handle = NULL;
+            }
+            if (i2c_bus->pm_lock) {
+                ESP_GOTO_ON_ERROR(esp_pm_lock_delete(i2c_bus->pm_lock), err, TAG, "delete pm_lock failed");
+                i2c_bus->pm_lock = NULL;
+            }
 #if I2C_USE_RETENTION_LINK
             if (i2c_bus->is_lp_i2c == false) {
                 if (i2c_bus->retention_link_created) {
@@ -206,12 +215,8 @@ esp_err_t i2c_release_bus_handle(i2c_bus_handle_t i2c_bus)
                 sleep_retention_module_deinit(i2c_regs_retention[port_num].module_id);
             }
 #endif
-            if (i2c_bus->intr_handle) {
-                ESP_RETURN_ON_ERROR(esp_intr_free(i2c_bus->intr_handle), TAG, "delete interrupt service failed");
-            }
-            if (i2c_bus->pm_lock) {
-                ESP_RETURN_ON_ERROR(esp_pm_lock_delete(i2c_bus->pm_lock), TAG, "delete pm_lock failed");
-            }
+            s_i2c_platform.count[port_num] = 0;
+            s_i2c_platform.buses[port_num] = NULL;
             // Disable I2C module
             if (!i2c_bus->is_lp_i2c) {
                 I2C_RCC_ATOMIC() {
@@ -244,8 +249,11 @@ esp_err_t i2c_release_bus_handle(i2c_bus_handle_t i2c_bus)
         ESP_LOGD(TAG, "delete bus %d", port_num);
     }
 
-    ESP_RETURN_ON_FALSE(s_i2c_platform.count[port_num] == 0, ESP_ERR_INVALID_STATE, TAG, "Bus not freed entirely");
     return ESP_OK;
+
+err:
+    _lock_release(&s_i2c_platform.mutex);
+    return ret;
 }
 
 esp_err_t i2c_select_periph_clock(i2c_bus_handle_t handle, soc_module_clk_t clk_src)

--- a/components/esp_driver_i2c/i2c_master.c
+++ b/components/esp_driver_i2c/i2c_master.c
@@ -946,41 +946,49 @@ static esp_err_t i2c_param_master_config(i2c_bus_handle_t handle, const i2c_mast
 
 static esp_err_t i2c_master_bus_destroy(i2c_master_bus_handle_t bus_handle)
 {
-    ESP_RETURN_ON_FALSE(bus_handle, ESP_ERR_INVALID_ARG, TAG, "no memory for i2c master bus");
+    ESP_RETURN_ON_FALSE(bus_handle, ESP_ERR_INVALID_ARG, TAG, "invalid argument");
     i2c_master_bus_handle_t i2c_master = bus_handle;
     esp_err_t err = ESP_OK;
+
     if (i2c_master->base) {
-        i2c_common_deinit_pins(i2c_master->base);
-        err = i2c_release_bus_handle(i2c_master->base);
-    }
-    if (err == ESP_OK) {
-        if (i2c_master) {
-            if (i2c_master->bus_lock_mux) {
-                vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
-                i2c_master->bus_lock_mux = NULL;
-            }
-            if (i2c_master->cmd_semphr) {
-                vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
-                i2c_master->cmd_semphr = NULL;
-            }
-            if (i2c_master->event_queue) {
-                vQueueDeleteWithCaps(i2c_master->event_queue);
-            }
-            free(i2c_master->i2c_async_ops);
-            for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
-                if (i2c_master->trans_queues[i]) {
-                    vQueueDelete(i2c_master->trans_queues[i]);
-                }
-            }
-            bus_handle = NULL;
+        err = i2c_common_deinit_pins(i2c_master->base);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to deinit i2c pins: %s", esp_err_to_name(err));
         }
-
-        free(i2c_master);
-    } else {
-        free(i2c_master);
+        esp_err_t release_ret = i2c_release_bus_handle(i2c_master->base);
+        if (release_ret != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release bus handle: %s", esp_err_to_name(release_ret));
+            if (err == ESP_OK) {
+                err = release_ret;
+            }
+            // The ISR may still refer to the bus and its owned resources.
+            return err;
+        }
     }
 
-    return ESP_OK;
+    if (i2c_master->bus_lock_mux) {
+        vSemaphoreDeleteWithCaps(i2c_master->bus_lock_mux);
+        i2c_master->bus_lock_mux = NULL;
+    }
+    if (i2c_master->cmd_semphr) {
+        vSemaphoreDeleteWithCaps(i2c_master->cmd_semphr);
+        i2c_master->cmd_semphr = NULL;
+    }
+    if (i2c_master->event_queue) {
+        vQueueDeleteWithCaps(i2c_master->event_queue);
+        i2c_master->event_queue = NULL;
+    }
+    free(i2c_master->i2c_async_ops);
+    i2c_master->i2c_async_ops = NULL;
+    for (int i = 0; i < I2C_TRANS_QUEUE_MAX; i++) {
+        if (i2c_master->trans_queues[i]) {
+            vQueueDelete(i2c_master->trans_queues[i]);
+            i2c_master->trans_queues[i] = NULL;
+        }
+    }
+
+    free(i2c_master);
+    return err;
 }
 
 static esp_err_t s_i2c_asynchronous_transaction(i2c_master_dev_handle_t i2c_dev, i2c_operation_t *i2c_ops, size_t ops_dim, int timeout_ms)

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -205,6 +205,7 @@ typedef struct {
     uint8_t active;
     bool pending;
     bool loaded;
+    bool enabled;
 } i2c_slave_default_response_t;
 
 #if !CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
@@ -245,6 +246,7 @@ struct i2c_slave_dev_t {
     bool receive_overflow;                            // bytes were dropped in the current receive transaction
     bool request_pending;                             // target is stretching while waiting for transmit data
     bool transmit_active;                             // controller is reading from the target
+    bool buffered_write_pending;                      // application will continue a partially buffered response
 };
 
 #endif // CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -199,6 +199,14 @@ typedef struct {
     uint32_t rcv_fifo_cnt;      // receive fifo count.
 } i2c_slave_receive_t;
 
+typedef struct {
+    uint8_t data[2][SOC_I2C_FIFO_LEN];
+    uint8_t length[2];
+    uint8_t active;
+    bool pending;
+    bool loaded;
+} i2c_slave_default_response_t;
+
 #if !CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
 
 struct i2c_slave_dev_t {
@@ -233,6 +241,7 @@ struct i2c_slave_dev_t {
     uint32_t rx_data_count;                           // receive data count
     uint32_t tx_data_count;                           // callback-provided bytes loaded for the current transaction
     i2c_slave_receive_t receive_desc;                 // slave receive descriptor
+    i2c_slave_default_response_t *default_response;   // fallback response used while the transmit stream is empty
     bool receive_overflow;                            // bytes were dropped in the current receive transaction
     bool request_pending;                             // target is stretching while waiting for transmit data
     bool transmit_active;                             // controller is reading from the target

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -44,8 +44,10 @@ extern "C" {
 
 #if CONFIG_I2C_ISR_IRAM_SAFE
 #define I2C_MEM_ALLOC_CAPS    (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT)
+#define I2C_SLAVE_ISR_ATTR    IRAM_ATTR
 #else
 #define I2C_MEM_ALLOC_CAPS     (MALLOC_CAP_DEFAULT)
+#define I2C_SLAVE_ISR_ATTR
 #endif
 
 // I2C driver object is per-mode, the interrupt source is shared between modes

--- a/components/esp_driver_i2c/i2c_private.h
+++ b/components/esp_driver_i2c/i2c_private.h
@@ -234,7 +234,7 @@ struct i2c_slave_dev_t {
     uint32_t tx_data_count;                           // callback-provided bytes loaded for the current transaction
     i2c_slave_receive_t receive_desc;                 // slave receive descriptor
     bool receive_overflow;                            // bytes were dropped in the current receive transaction
-    bool request_pending;                             // target is stretching at a read address match
+    bool request_pending;                             // target is stretching while waiting for transmit data
     bool transmit_active;                             // controller is reading from the target
 };
 

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -244,8 +244,40 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
             i2c_ll_slave_clear_stretch(hal->dev);
         }
     } else if (cause == I2C_SLAVE_STRETCH_CAUSE_TX_EMPTY) {
-        xTaskWoken |= i2c_slave_handle_tx_fifo(i2c_slave, NULL);
-        i2c_ll_slave_clear_stretch(hal->dev);
+        // Make the request visible before checking the software buffer. This
+        // closes the race with i2c_slave_write: if a writer queues data while
+        // the ISR is servicing TX_EMPTY, it can fill the FIFO and release the
+        // stretch itself.
+        portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        bool transmit_active = i2c_slave->transmit_active;
+        i2c_slave->request_pending = transmit_active;
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+
+        // TX_EMPTY can be latched together with transaction completion after
+        // the controller NACKs the last byte. It no longer represents a data
+        // request in that case.
+        if (!transmit_active) {
+            i2c_ll_slave_clear_stretch(hal->dev);
+            return xTaskWoken;
+        }
+
+        size_t loaded = 0;
+        xTaskWoken |= i2c_slave_handle_tx_fifo(i2c_slave, &loaded);
+        if (loaded != 0) {
+            portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_slave->request_pending = false;
+            portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_ll_slave_clear_stretch(hal->dev);
+        } else {
+            bool request_pending;
+            portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            request_pending = i2c_slave->request_pending;
+            portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            if (request_pending && i2c_slave->request_callback) {
+                i2c_slave_request_event_data_t evt_data = {};
+                xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
+            }
+        }
     } else if (cause == I2C_SLAVE_STRETCH_CAUSE_RX_FULL) {
         xTaskWoken |= i2c_slave_handle_rx_fifo(i2c_slave, rx_fifo_exist_len);
         i2c_ll_slave_clear_stretch(hal->dev);
@@ -307,8 +339,10 @@ IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
         if (slave_rw == I2C_SLAVE_READ_BY_MASTER) {
             portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_slave->request_pending = false;
             i2c_slave->transmit_active = false;
             portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_ll_slave_clear_stretch(hal->dev);
         }
 #endif
     }

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -32,7 +32,7 @@
 
 static const char *TAG = "i2c.slave";
 
-IRAM_ATTR static bool i2c_slave_read_rx(i2c_slave_dev_t *i2c_slave, uint8_t *data, size_t len, size_t *read_len)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_read_rx(i2c_slave_dev_t *i2c_slave, uint8_t *data, size_t len, size_t *read_len)
 {
     BaseType_t xTaskWoken = pdFALSE;
     size_t read_size = len;
@@ -62,7 +62,7 @@ IRAM_ATTR static bool i2c_slave_read_rx(i2c_slave_dev_t *i2c_slave, uint8_t *dat
     return xTaskWoken;
 }
 
-IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_t *loaded)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_t *loaded)
 {
     BaseType_t xTaskWoken = pdFALSE;
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
@@ -129,7 +129,7 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
 }
 
 // The caller must hold the bus spinlock.
-IRAM_ATTR static void i2c_slave_discard_tx_buffer_from_isr(
+I2C_SLAVE_ISR_ATTR static void i2c_slave_discard_tx_buffer_from_isr(
     i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
 {
     while (true) {
@@ -143,7 +143,7 @@ IRAM_ATTR static void i2c_slave_discard_tx_buffer_from_isr(
     }
 }
 
-IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
 {
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
     portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
@@ -205,7 +205,7 @@ IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_sla
 }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
-IRAM_ATTR static bool i2c_slave_load_default_response(i2c_slave_dev_t *i2c_slave)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_load_default_response(i2c_slave_dev_t *i2c_slave)
 {
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
     portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
@@ -228,7 +228,7 @@ IRAM_ATTR static bool i2c_slave_load_default_response(i2c_slave_dev_t *i2c_slave
     return true;
 }
 
-IRAM_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
 {
     if (!i2c_slave->transmit_callback) {
         return false;
@@ -262,7 +262,7 @@ IRAM_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
 }
 #endif
 
-IRAM_ATTR static bool i2c_slave_handle_rx_fifo(i2c_slave_dev_t *i2c_slave, uint32_t len)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_handle_rx_fifo(i2c_slave_dev_t *i2c_slave, uint32_t len)
 {
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
     uint8_t data[SOC_I2C_FIFO_LEN];
@@ -318,7 +318,7 @@ static void i2c_slave_discard_tx_buffer(i2c_slave_dev_t *i2c_slave)
 #endif
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
-IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave, uint32_t rx_fifo_exist_len, i2c_slave_read_write_status_t slave_rw)
+I2C_SLAVE_ISR_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave, uint32_t rx_fifo_exist_len, i2c_slave_read_write_status_t slave_rw)
 {
     i2c_slave_stretch_cause_t cause;
     BaseType_t xTaskWoken = pdFALSE;
@@ -464,7 +464,7 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
 }
 #endif
 
-IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
+I2C_SLAVE_ISR_ATTR static void i2c_slave_isr_handler(void *arg)
 {
     BaseType_t pxHigherPriorityTaskWoken = false;
     i2c_slave_dev_t *i2c_slave = (i2c_slave_dev_t *)arg;
@@ -551,6 +551,11 @@ static esp_err_t i2c_slave_device_destroy(i2c_slave_dev_handle_t i2c_slave)
         i2c_ll_disable_intr_mask(i2c_slave->base->hal.dev, I2C_LL_SLAVE_EVENT_INTR);
         i2c_common_deinit_pins(i2c_slave->base);
         ret = i2c_release_bus_handle(i2c_slave->base);
+        if (ret != ESP_OK) {
+            // Interrupt teardown did not complete, so the ISR may still refer
+            // to the slave and its owned resources.
+            return ret;
+        }
     }
     if (i2c_slave->rx_ring_buf) {
         vRingbufferDeleteWithCaps(i2c_slave->rx_ring_buf);
@@ -959,7 +964,12 @@ esp_err_t i2c_slave_set_buffered_write_pending(i2c_slave_dev_handle_t i2c_slave,
     } else if (!pending && i2c_slave->request_pending && response && response->enabled) {
         uint32_t free_fifo_len = 0;
         i2c_ll_get_txfifo_len(i2c_slave->base->hal.dev, &free_fifo_len);
-        if (free_fifo_len == SOC_I2C_FIFO_LEN) {
+        size_t loaded = i2c_slave_fill_tx_fifo(i2c_slave, free_fifo_len);
+        if (loaded != 0) {
+            i2c_ll_slave_enable_tx_it(i2c_slave->base->hal.dev);
+            i2c_slave->request_pending = false;
+            release_request = true;
+        } else if (free_fifo_len == SOC_I2C_FIFO_LEN) {
             if (response->pending) {
                 response->active ^= 1;
                 response->pending = false;

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -812,11 +812,27 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     }
 #endif
 
-    xSemaphoreGive(i2c_slave->operation_mux);
     if (release_request) {
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+        UBaseType_t buffered_bytes = 0;
+        portENTER_CRITICAL(&i2c_slave->base->spinlock);
+        vRingbufferGetInfo(i2c_slave->tx_ring_buf, NULL, NULL, NULL, NULL, &buffered_bytes);
+        if (buffered_bytes != 0) {
+            i2c_ll_slave_enable_tx_it(hal->dev);
+        } else {
+            // Enabling the watermark interrupt for a short response makes it
+            // fire before the active stretch is released. Let TX-empty cause
+            // the next stretch instead.
+            i2c_ll_slave_disable_tx_it(hal->dev);
+        }
+        i2c_ll_slave_clear_stretch(hal->dev);
+        portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+#else
         i2c_ll_slave_enable_tx_it(hal->dev);
         i2c_ll_slave_clear_stretch(hal->dev);
+#endif
     }
+    xSemaphoreGive(i2c_slave->operation_mux);
 
     return ESP_OK;
 }

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -128,6 +128,21 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     return xTaskWoken;
 }
 
+// The caller must hold the bus spinlock.
+IRAM_ATTR static void i2c_slave_discard_tx_buffer_from_isr(
+    i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
+{
+    while (true) {
+        size_t length = 0;
+        uint8_t *data = xRingbufferReceiveUpToFromISR(
+                            i2c_slave->tx_ring_buf, &length, SIZE_MAX);
+        if (!data) {
+            return;
+        }
+        vRingbufferReturnItemFromISR(i2c_slave->tx_ring_buf, data, task_woken);
+    }
+}
+
 IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
 {
     i2c_hal_context_t *hal = &i2c_slave->base->hal;
@@ -139,6 +154,17 @@ IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_sla
     }
 
     i2c_ll_slave_disable_tx_it(hal->dev);
+    if (!response->enabled) {
+        // Handler responses belong to one controller transaction. A controller
+        // may NACK after the peripheral has already popped the following byte,
+        // so preserving a partial FIFO here cannot preserve the byte stream.
+        // Discard the whole tail and ask the handler again on the next read.
+        i2c_ll_txfifo_rst(hal->dev);
+        i2c_slave_discard_tx_buffer_from_isr(i2c_slave, task_woken);
+        response->loaded = false;
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        return true;
+    }
     if (response->loaded) {
         // Discard the remainder of the default response at the transaction
         // boundary before looking for an ordinary queued response.
@@ -162,7 +188,7 @@ IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_sla
     if (fifo_len != SOC_I2C_FIFO_LEN) {
         response->loaded = false;
         i2c_ll_slave_enable_tx_it(hal->dev);
-    } else {
+    } else if (response->enabled && !i2c_slave->buffered_write_pending) {
         if (response->pending) {
             response->active ^= 1;
             response->pending = false;
@@ -171,12 +197,37 @@ IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_sla
         i2c_ll_txfifo_rst(hal->dev);
         i2c_ll_write_txfifo(
             hal->dev, response->data[response->active], response->length[response->active]);
+    } else {
+        response->loaded = false;
     }
     portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
     return true;
 }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+IRAM_ATTR static bool i2c_slave_load_default_response(i2c_slave_dev_t *i2c_slave)
+{
+    i2c_hal_context_t *hal = &i2c_slave->base->hal;
+    portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    i2c_slave_default_response_t *response = i2c_slave->default_response;
+    if (!response || (!response->enabled && !response->loaded)) {
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        return false;
+    }
+    if (!response->loaded && response->pending) {
+        response->active ^= 1;
+        response->pending = false;
+    }
+    response->loaded = true;
+    i2c_slave->request_pending = false;
+    i2c_ll_slave_disable_tx_it(hal->dev);
+    i2c_ll_txfifo_rst(hal->dev);
+    i2c_ll_write_txfifo(
+        hal->dev, response->data[response->active], response->length[response->active]);
+    portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    return true;
+}
+
 IRAM_ATTR static bool i2c_slave_handle_tx_done(i2c_slave_dev_t *i2c_slave)
 {
     if (!i2c_slave->transmit_callback) {
@@ -251,6 +302,22 @@ static size_t i2c_slave_fill_tx_fifo(i2c_slave_dev_t *i2c_slave, size_t fifo_len
 }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+// The caller must hold the bus spinlock and operation_mux.
+static void i2c_slave_discard_tx_buffer(i2c_slave_dev_t *i2c_slave)
+{
+    while (true) {
+        size_t length = 0;
+        uint8_t *data = xRingbufferReceiveUpTo(
+                            i2c_slave->tx_ring_buf, &length, 0, SIZE_MAX);
+        if (!data) {
+            return;
+        }
+        vRingbufferReturnItem(i2c_slave->tx_ring_buf, data);
+    }
+}
+#endif
+
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
 IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave, uint32_t rx_fifo_exist_len, i2c_slave_read_write_status_t slave_rw)
 {
     i2c_slave_stretch_cause_t cause;
@@ -279,29 +346,47 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
             i2c_slave->rx_data_count = 0;
             i2c_slave->receive_overflow = false;
         }
-        i2c_slave_request_event_data_t evt_data = {};
-        if (i2c_slave->request_callback) {
-            xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
+        if (slave_rw != I2C_SLAVE_READ_BY_MASTER) {
+            portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_slave->request_pending = false;
+            portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_ll_slave_clear_stretch(hal->dev);
+            return xTaskWoken;
         }
         portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
-        bool default_response = i2c_slave->default_response != NULL;
+        bool default_response = i2c_slave->default_response &&
+                                i2c_slave->default_response->loaded;
         portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
         if (default_response) {
+            portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+            i2c_slave->request_pending = false;
+            portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
             i2c_ll_slave_clear_stretch(hal->dev);
             return xTaskWoken;
         }
         // Data may have been queued before the request. Move it into the FIFO
         // and release the address-match stretch without requiring another
-        // i2c_slave_write call. If no data is available, keep stretching so the
-        // request callback can wake a task that produces the response.
+        // i2c_slave_write call. Bytes left in the FIFO by a short controller
+        // read are part of the same buffered response and are used first.
         size_t loaded = 0;
         xTaskWoken |= i2c_slave_handle_tx_fifo(i2c_slave, &loaded);
-        if (loaded != 0) {
+        uint32_t free_fifo_len = 0;
+        portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        if (loaded != 0 || free_fifo_len != SOC_I2C_FIFO_LEN) {
             i2c_ll_slave_enable_tx_it(hal->dev);
             portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
             i2c_slave->request_pending = false;
             portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
             i2c_ll_slave_clear_stretch(hal->dev);
+        } else {
+            // Keep stretching while the request callback wakes the task that
+            // will produce the next response.
+            i2c_slave_request_event_data_t evt_data = {};
+            if (i2c_slave->request_callback) {
+                xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
+            }
         }
     } else if (cause == I2C_SLAVE_STRETCH_CAUSE_TX_EMPTY) {
         // Make the request visible before checking the software buffer. This
@@ -321,6 +406,21 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
             return xTaskWoken;
         }
 
+        portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        bool continuing_default = i2c_slave->default_response &&
+                                  i2c_slave->default_response->loaded;
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        if (continuing_default && i2c_slave_load_default_response(i2c_slave)) {
+            // Do not splice data queued during an active fallback transaction
+            // into that transaction. Repeat the already selected fallback and
+            // leave the queued data for the next transaction boundary.
+            i2c_ll_slave_clear_stretch(hal->dev);
+            return xTaskWoken;
+        }
+
+        // When the current stream is explicit, its software-buffered tail has
+        // priority over starting a fallback. The watermark and TX-empty causes
+        // can be co-latched, so drain it here before loading the fallback.
         size_t loaded = 0;
         xTaskWoken |= i2c_slave_handle_tx_fifo(i2c_slave, &loaded);
         if (loaded != 0) {
@@ -329,13 +429,31 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
             portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
             i2c_ll_slave_clear_stretch(hal->dev);
         } else {
-            bool request_pending;
+            bool buffered_write_pending;
             portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
-            request_pending = i2c_slave->request_pending;
+            buffered_write_pending = i2c_slave->buffered_write_pending;
             portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
-            if (request_pending && i2c_slave->request_callback) {
-                i2c_slave_request_event_data_t evt_data = {};
-                xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
+            if (buffered_write_pending) {
+                if (i2c_slave->request_callback) {
+                    i2c_slave_request_event_data_t evt_data = {};
+                    xTaskWoken |= i2c_slave->request_callback(
+                                      i2c_slave, &evt_data, i2c_slave->user_ctx);
+                }
+                return xTaskWoken;
+            }
+            if (i2c_slave_load_default_response(i2c_slave)) {
+                // Repeat a default response, or start it after an explicitly
+                // queued response was exhausted without ending the transaction.
+                i2c_ll_slave_clear_stretch(hal->dev);
+            } else {
+                bool request_pending;
+                portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+                request_pending = i2c_slave->request_pending;
+                portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+                if (request_pending && i2c_slave->request_callback) {
+                    i2c_slave_request_event_data_t evt_data = {};
+                    xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
+                }
             }
         }
     } else if (cause == I2C_SLAVE_STRETCH_CAUSE_RX_FULL) {
@@ -586,6 +704,9 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     bool request_pending = true;
     bool release_request = false;
     bool default_loaded = false;
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+    bool default_superseded = false;
+#endif
 
     if (xSemaphoreTake(i2c_slave->operation_mux, wait_ticks) != pdTRUE) {
         return ESP_ERR_TIMEOUT;
@@ -599,6 +720,26 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
         return ESP_ERR_INVALID_STATE;
     }
     default_loaded = i2c_slave->default_response && i2c_slave->default_response->loaded;
+    bool transmit_active = i2c_slave->transmit_active;
+#if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+    // The original ESP32 has no address-match stretch interrupt from which to
+    // maintain transmit_active. Its bus status is sufficient to avoid
+    // replacing a default response in the middle of an active controller
+    // read; data queued then is staged for the following transaction.
+    transmit_active = i2c_ll_is_bus_busy(hal->dev) &&
+                      i2c_ll_slave_get_read_write_status(hal->dev) == I2C_SLAVE_READ_BY_MASTER;
+#endif
+    if (default_loaded && !transmit_active) {
+        // Data queued before a transaction starts supersedes the preloaded
+        // default immediately. A write racing an active default transaction
+        // is staged for the following transaction instead.
+        i2c_ll_txfifo_rst(hal->dev);
+        i2c_slave->default_response->loaded = false;
+        default_loaded = false;
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+        default_superseded = true;
+#endif
+    }
     if (!default_loaded) {
 #if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
         i2c_ll_slave_disable_tx_it(hal->dev);
@@ -609,7 +750,7 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
             i2c_ll_txfifo_rst(hal->dev);
         }
 #else
-        request_pending = i2c_slave->request_pending;
+        request_pending = i2c_slave->request_pending || default_superseded;
 #endif
         if (request_pending) {
             i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
@@ -708,6 +849,7 @@ esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const
             memcpy(allocated->data[0], data, len);
             allocated->length[0] = len;
             allocated->loaded = true;
+            allocated->enabled = true;
             i2c_slave->default_response = allocated;
             allocated = NULL;
             i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
@@ -737,6 +879,108 @@ esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const
     }
     ESP_RETURN_ON_ERROR(ret, TAG, "cannot set a default response while transmit data is pending");
     return ESP_OK;
+}
+
+esp_err_t i2c_slave_set_default_response_enabled(i2c_slave_dev_handle_t i2c_slave, bool enabled)
+{
+    ESP_RETURN_ON_FALSE(i2c_slave, ESP_ERR_INVALID_ARG, TAG, "i2c slave not initialized");
+#if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+    ESP_RETURN_ON_FALSE(enabled, ESP_ERR_NOT_SUPPORTED, TAG, "target cannot wait for a response");
+    return ESP_OK;
+#else
+    ESP_RETURN_ON_FALSE(xSemaphoreTake(i2c_slave->operation_mux, 0) == pdTRUE,
+                        ESP_ERR_TIMEOUT, TAG, "another operation is in progress");
+
+    bool release_request = false;
+    portENTER_CRITICAL(&i2c_slave->base->spinlock);
+    i2c_slave_default_response_t *response = i2c_slave->default_response;
+    if (!response) {
+        portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+        xSemaphoreGive(i2c_slave->operation_mux);
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    response->enabled = enabled;
+    if (!enabled) {
+        if (!i2c_slave->transmit_active && response->loaded) {
+            i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
+            i2c_ll_txfifo_rst(i2c_slave->base->hal.dev);
+            response->loaded = false;
+        }
+    } else {
+        // Leaving handler mode abandons that handler's complete response
+        // stream. This includes bytes staged in the software ring buffer.
+        i2c_slave_discard_tx_buffer(i2c_slave);
+        if (response->pending) {
+            response->active ^= 1;
+            response->pending = false;
+        }
+        i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
+        i2c_ll_txfifo_rst(i2c_slave->base->hal.dev);
+        i2c_ll_write_txfifo(i2c_slave->base->hal.dev,
+                            response->data[response->active],
+                            response->length[response->active]);
+        response->loaded = true;
+        if (i2c_slave->request_pending) {
+            i2c_slave->request_pending = false;
+            release_request = true;
+        }
+    }
+    portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+    xSemaphoreGive(i2c_slave->operation_mux);
+
+    if (release_request) {
+        i2c_ll_slave_clear_stretch(i2c_slave->base->hal.dev);
+    }
+    return ESP_OK;
+#endif
+}
+
+esp_err_t i2c_slave_set_buffered_write_pending(i2c_slave_dev_handle_t i2c_slave, bool pending)
+{
+    ESP_RETURN_ON_FALSE(i2c_slave, ESP_ERR_INVALID_ARG, TAG, "i2c slave not initialized");
+#if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+    return ESP_OK;
+#else
+    ESP_RETURN_ON_FALSE(xSemaphoreTake(i2c_slave->operation_mux, 0) == pdTRUE,
+                        ESP_ERR_TIMEOUT, TAG, "another operation is in progress");
+
+    bool release_request = false;
+    portENTER_CRITICAL(&i2c_slave->base->spinlock);
+    i2c_slave->buffered_write_pending = pending;
+    i2c_slave_default_response_t *response = i2c_slave->default_response;
+    if (pending && response && response->loaded && !i2c_slave->transmit_active) {
+        // A complete blocking write is about to supersede an idle preloaded
+        // fallback. If a fallback transaction is active, leave it untouched
+        // and stage the new response for the next boundary.
+        i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
+        i2c_ll_txfifo_rst(i2c_slave->base->hal.dev);
+        response->loaded = false;
+    } else if (!pending && i2c_slave->request_pending && response && response->enabled) {
+        uint32_t free_fifo_len = 0;
+        i2c_ll_get_txfifo_len(i2c_slave->base->hal.dev, &free_fifo_len);
+        if (free_fifo_len == SOC_I2C_FIFO_LEN) {
+            if (response->pending) {
+                response->active ^= 1;
+                response->pending = false;
+            }
+            i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
+            i2c_ll_write_txfifo(i2c_slave->base->hal.dev,
+                                response->data[response->active],
+                                response->length[response->active]);
+            response->loaded = true;
+            i2c_slave->request_pending = false;
+            release_request = true;
+        }
+    }
+    portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+    xSemaphoreGive(i2c_slave->operation_mux);
+
+    if (release_request) {
+        i2c_ll_slave_clear_stretch(i2c_slave->base->hal.dev);
+    }
+    return ESP_OK;
+#endif
 }
 
 esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, const i2c_slave_event_callbacks_t *cbs, void *user_data)

--- a/components/esp_driver_i2c/i2c_slave_v2.c
+++ b/components/esp_driver_i2c/i2c_slave_v2.c
@@ -71,6 +71,11 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     i2c_slave_transmit_callback_t transmit_callback;
     void *user_ctx;
     portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    if (i2c_slave->default_response && i2c_slave->default_response->loaded) {
+        i2c_ll_slave_disable_tx_it(hal->dev);
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        return xTaskWoken;
+    }
     i2c_ll_get_txfifo_len(hal->dev, &fifo_len);
     transmit_callback = i2c_slave->transmit_callback;
     user_ctx = i2c_slave->user_ctx;
@@ -121,6 +126,54 @@ IRAM_ATTR static bool i2c_slave_handle_tx_fifo(i2c_slave_dev_t *i2c_slave, size_
     }
     portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
     return xTaskWoken;
+}
+
+IRAM_ATTR static bool i2c_slave_handle_default_response(i2c_slave_dev_t *i2c_slave, BaseType_t *task_woken)
+{
+    i2c_hal_context_t *hal = &i2c_slave->base->hal;
+    portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    i2c_slave_default_response_t *response = i2c_slave->default_response;
+    if (!response) {
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        return false;
+    }
+
+    i2c_ll_slave_disable_tx_it(hal->dev);
+    if (response->loaded) {
+        // Discard the remainder of the default response at the transaction
+        // boundary before looking for an ordinary queued response.
+        i2c_ll_txfifo_rst(hal->dev);
+    }
+
+    uint32_t fifo_len = 0;
+    i2c_ll_get_txfifo_len(hal->dev, &fifo_len);
+    while (fifo_len > 0) {
+        size_t actual_get_len = 0;
+        uint8_t *data = xRingbufferReceiveUpToFromISR(
+                            i2c_slave->tx_ring_buf, &actual_get_len, fifo_len);
+        if (!data) {
+            break;
+        }
+        i2c_ll_write_txfifo(hal->dev, data, actual_get_len);
+        fifo_len -= actual_get_len;
+        vRingbufferReturnItemFromISR(i2c_slave->tx_ring_buf, data, task_woken);
+    }
+
+    if (fifo_len != SOC_I2C_FIFO_LEN) {
+        response->loaded = false;
+        i2c_ll_slave_enable_tx_it(hal->dev);
+    } else {
+        if (response->pending) {
+            response->active ^= 1;
+            response->pending = false;
+        }
+        response->loaded = true;
+        i2c_ll_txfifo_rst(hal->dev);
+        i2c_ll_write_txfifo(
+            hal->dev, response->data[response->active], response->length[response->active]);
+    }
+    portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+    return true;
 }
 
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
@@ -230,6 +283,13 @@ IRAM_ATTR static bool i2c_slave_handle_stretch_event(i2c_slave_dev_t *i2c_slave,
         if (i2c_slave->request_callback) {
             xTaskWoken |= i2c_slave->request_callback(i2c_slave, &evt_data, i2c_slave->user_ctx);
         }
+        portENTER_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        bool default_response = i2c_slave->default_response != NULL;
+        portEXIT_CRITICAL_ISR(&i2c_slave->base->spinlock);
+        if (default_response) {
+            i2c_ll_slave_clear_stretch(hal->dev);
+            return xTaskWoken;
+        }
         // Data may have been queued before the request. Move it into the FIFO
         // and release the address-match stretch without requiring another
         // i2c_slave_write call. If no data is available, keep stretching so the
@@ -305,8 +365,12 @@ IRAM_ATTR static void i2c_slave_isr_handler(void *arg)
     }
 
     if (int_mask & I2C_INTR_SLV_COMPLETE) {
-#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
         if (slave_rw == I2C_SLAVE_READ_BY_MASTER) {
+            transmit_done = i2c_slave_handle_default_response(
+                                i2c_slave, &pxHigherPriorityTaskWoken);
+        }
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+        if (slave_rw == I2C_SLAVE_READ_BY_MASTER && !transmit_done) {
             pxHigherPriorityTaskWoken |= i2c_slave_handle_tx_done(i2c_slave);
             transmit_done = i2c_slave->transmit_callback != NULL;
         }
@@ -384,6 +448,9 @@ static esp_err_t i2c_slave_device_destroy(i2c_slave_dev_handle_t i2c_slave)
     }
     if (i2c_slave->receive_desc.buffer) {
         free(i2c_slave->receive_desc.buffer);
+    }
+    if (i2c_slave->default_response) {
+        free(i2c_slave->default_response);
     }
 
     free(i2c_slave);
@@ -518,6 +585,7 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     TickType_t wait_ticks = (timeout_ms == -1) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
     bool request_pending = true;
     bool release_request = false;
+    bool default_loaded = false;
 
     if (xSemaphoreTake(i2c_slave->operation_mux, wait_ticks) != pdTRUE) {
         return ESP_ERR_TIMEOUT;
@@ -530,38 +598,41 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
         ESP_LOGE(TAG, "transmit callback is registered");
         return ESP_ERR_INVALID_STATE;
     }
+    default_loaded = i2c_slave->default_response && i2c_slave->default_response->loaded;
+    if (!default_loaded) {
 #if !SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
-    i2c_ll_slave_disable_tx_it(hal->dev);
-    uint32_t txfifo_len = 0;
-    i2c_ll_get_txfifo_len(hal->dev, &txfifo_len);
-    if (txfifo_len < SOC_I2C_FIFO_LEN) {
-        // For the target (esp32) cannot stretch, reset the fifo when there is any dirty data in fifo.
-        i2c_ll_txfifo_rst(hal->dev);
-    }
+        i2c_ll_slave_disable_tx_it(hal->dev);
+        uint32_t txfifo_len = 0;
+        i2c_ll_get_txfifo_len(hal->dev, &txfifo_len);
+        if (txfifo_len < SOC_I2C_FIFO_LEN) {
+            // For the target (esp32) cannot stretch, reset the fifo when there is any dirty data in fifo.
+            i2c_ll_txfifo_rst(hal->dev);
+        }
 #else
-    request_pending = i2c_slave->request_pending;
+        request_pending = i2c_slave->request_pending;
 #endif
-    if (request_pending) {
-        i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
-    }
+        if (request_pending) {
+            i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
+        }
 
-    // Check if there is any data in the ringbuffer from the last transaction.
-    size_t existing_size = i2c_slave_fill_tx_fifo(i2c_slave, free_fifo_len);
-    free_fifo_len -= existing_size;
+        // Check if there is any data in the ringbuffer from the last transaction.
+        size_t existing_size = i2c_slave_fill_tx_fifo(i2c_slave, free_fifo_len);
+        free_fifo_len -= existing_size;
 
-    // Write data.
-    if (free_fifo_len) {
-        actual_write_fifo_size = len < free_fifo_len ? len : free_fifo_len;
-        i2c_ll_write_txfifo(hal->dev, (uint8_t *)data, actual_write_fifo_size);
-        data += actual_write_fifo_size;
-        len -= actual_write_fifo_size;
-    }
-    release_request = request_pending && (existing_size + actual_write_fifo_size) != 0;
+        // Write data.
+        if (free_fifo_len) {
+            actual_write_fifo_size = len < free_fifo_len ? len : free_fifo_len;
+            i2c_ll_write_txfifo(hal->dev, (uint8_t *)data, actual_write_fifo_size);
+            data += actual_write_fifo_size;
+            len -= actual_write_fifo_size;
+        }
+        release_request = request_pending && (existing_size + actual_write_fifo_size) != 0;
 #if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
-    if (release_request) {
-        i2c_slave->request_pending = false;
-    }
+        if (release_request) {
+            i2c_slave->request_pending = false;
+        }
 #endif
+    }
     portEXIT_CRITICAL(&i2c_slave->base->spinlock);
 
     if (len) {
@@ -581,7 +652,7 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
     // An address match can race with the ringbuffer send above. If the ISR saw
     // the empty buffer, finish servicing the request here after the data has
     // become visible. The ISR can always run while operation_mux is held.
-    if (!release_request && write_ringbuffer_len != 0) {
+    if (!default_loaded && !release_request && write_ringbuffer_len != 0) {
         portENTER_CRITICAL(&i2c_slave->base->spinlock);
         if (i2c_slave->request_pending) {
             i2c_ll_get_txfifo_len(hal->dev, &free_fifo_len);
@@ -601,6 +672,70 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
         i2c_ll_slave_clear_stretch(hal->dev);
     }
 
+    return ESP_OK;
+}
+
+esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data, uint32_t len)
+{
+    ESP_RETURN_ON_FALSE(i2c_slave, ESP_ERR_INVALID_ARG, TAG, "i2c slave not initialized");
+    ESP_RETURN_ON_FALSE(data, ESP_ERR_INVALID_ARG, TAG, "invalid data buffer");
+    ESP_RETURN_ON_FALSE(len > 0 && len <= SOC_I2C_FIFO_LEN, ESP_ERR_INVALID_ARG, TAG, "response does not fit in hardware FIFO");
+    ESP_RETURN_ON_FALSE(xSemaphoreTake(i2c_slave->operation_mux, 0) == pdTRUE, ESP_ERR_TIMEOUT, TAG, "another operation is in progress");
+
+    i2c_slave_default_response_t *allocated = NULL;
+    if (!i2c_slave->default_response) {
+        allocated = heap_caps_calloc(1, sizeof(i2c_slave_default_response_t), I2C_MEM_ALLOC_CAPS);
+        if (!allocated) {
+            xSemaphoreGive(i2c_slave->operation_mux);
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    esp_err_t ret = ESP_OK;
+    bool release_request = false;
+    portENTER_CRITICAL(&i2c_slave->base->spinlock);
+    if (i2c_slave->transmit_callback) {
+        ret = ESP_ERR_INVALID_STATE;
+    } else if (!i2c_slave->default_response) {
+        UBaseType_t buffered_bytes = 0;
+        uint32_t free_fifo_len = 0;
+        vRingbufferGetInfo(i2c_slave->tx_ring_buf, NULL, NULL, NULL, NULL, &buffered_bytes);
+        i2c_ll_get_txfifo_len(i2c_slave->base->hal.dev, &free_fifo_len);
+        if (i2c_slave->tx_data_count != 0 || buffered_bytes != 0 ||
+                free_fifo_len != SOC_I2C_FIFO_LEN) {
+            ret = ESP_ERR_INVALID_STATE;
+        } else {
+            memcpy(allocated->data[0], data, len);
+            allocated->length[0] = len;
+            allocated->loaded = true;
+            i2c_slave->default_response = allocated;
+            allocated = NULL;
+            i2c_ll_slave_disable_tx_it(i2c_slave->base->hal.dev);
+            i2c_ll_txfifo_rst(i2c_slave->base->hal.dev);
+            i2c_ll_write_txfifo(i2c_slave->base->hal.dev,
+                                i2c_slave->default_response->data[0], len);
+#if SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE
+            if (i2c_slave->request_pending) {
+                i2c_slave->request_pending = false;
+                release_request = true;
+            }
+#endif
+        }
+    } else {
+        i2c_slave_default_response_t *response = i2c_slave->default_response;
+        uint8_t pending = response->active ^ 1;
+        memcpy(response->data[pending], data, len);
+        response->length[pending] = len;
+        response->pending = true;
+    }
+    portEXIT_CRITICAL(&i2c_slave->base->spinlock);
+
+    free(allocated);
+    xSemaphoreGive(i2c_slave->operation_mux);
+    if (release_request) {
+        i2c_ll_slave_clear_stretch(i2c_slave->base->hal.dev);
+    }
+    ESP_RETURN_ON_ERROR(ret, TAG, "cannot set a default response while transmit data is pending");
     return ESP_OK;
 }
 
@@ -635,6 +770,8 @@ esp_err_t i2c_slave_register_event_callbacks(i2c_slave_dev_handle_t i2c_slave, c
     esp_err_t ret = ESP_OK;
     portENTER_CRITICAL(&i2c_slave->base->spinlock);
     if (i2c_slave->transmit_active) {
+        ret = ESP_ERR_INVALID_STATE;
+    } else if (i2c_slave->default_response && cbs->on_transmit) {
         ret = ESP_ERR_INVALID_STATE;
     } else if (i2c_slave->transmit_callback != cbs->on_transmit) {
         UBaseType_t buffered_bytes = 0;

--- a/components/esp_driver_i2c/include/driver/i2c_slave.h
+++ b/components/esp_driver_i2c/include/driver/i2c_slave.h
@@ -199,8 +199,10 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
  * more before receiving the queued data. A later call to this function stages
  * a replacement that is installed the next time the default is loaded.
  *
- * The default response must fit in the hardware FIFO. A controller must not
- * read more bytes than the selected default or buffered response contains.
+ * The default response must fit in the hardware FIFO. Targets with
+ * response-time clock stretching repeat it when a controller continues past
+ * the selected default or buffered response. On targets without that
+ * capability, a controller must not read beyond the available bytes.
  *
  * @param[in] i2c_slave I2C slave device handle that created by `i2c_new_slave_device`.
  * @param[in] data Response returned when no buffered transmit data is available.
@@ -213,6 +215,49 @@ esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data,
  *      - ESP_ERR_TIMEOUT: Another operation is in progress.
  */
 esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data, uint32_t len);
+
+/**
+ * @brief Enables or suppresses the configured default response.
+ *
+ * Suppressing the response keeps its contents but lets an address-match or
+ * TX-empty event stretch SCL while application code supplies data. Enabling
+ * it discards any buffered application response and preloads the default. If
+ * the target is already stretching for transmit data, enabling the response
+ * supplies it immediately and releases SCL.
+ *
+ * Disabling is not supported on targets without response-time clock
+ * stretching. If disabled during a transaction already using the default
+ * response, that transaction continues using it until its boundary.
+ *
+ * @param i2c_slave I2C slave device handle.
+ * @param enabled Whether the default response should be served.
+ * @return
+ *      - ESP_OK: The mode was changed.
+ *      - ESP_ERR_INVALID_ARG: The handle is invalid.
+ *      - ESP_ERR_INVALID_STATE: No default response has been configured.
+ *      - ESP_ERR_NOT_SUPPORTED: The target cannot suppress the response.
+ *      - ESP_ERR_TIMEOUT: Another operation is in progress.
+ */
+esp_err_t i2c_slave_set_default_response_enabled(i2c_slave_dev_handle_t i2c_slave, bool enabled);
+
+/**
+ * @brief Records whether a buffered response is still being produced.
+ *
+ * While pending, exhausting currently buffered bytes wakes the request
+ * callback and stretches instead of selecting the default response. Clearing
+ * the flag selects and releases a default immediately if the target is
+ * already waiting and no response data remains.
+ *
+ * This is a no-op on targets without response-time clock stretching.
+ *
+ * @param i2c_slave I2C slave device handle.
+ * @param pending Whether more bytes of the current buffered response follow.
+ * @return
+ *      - ESP_OK: The state was changed.
+ *      - ESP_ERR_INVALID_ARG: The handle is invalid.
+ *      - ESP_ERR_TIMEOUT: Another operation is in progress.
+ */
+esp_err_t i2c_slave_set_buffered_write_pending(i2c_slave_dev_handle_t i2c_slave, bool pending);
 
 #endif // CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
 

--- a/components/esp_driver_i2c/include/driver/i2c_slave.h
+++ b/components/esp_driver_i2c/include/driver/i2c_slave.h
@@ -186,6 +186,34 @@ typedef struct {
  */
 esp_err_t i2c_slave_write(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data, uint32_t len, uint32_t *write_len, int timeout_ms);
 
+/**
+ * @brief Set the response served while no buffered transmit data is available.
+ *
+ * The default response is loaded from the start for every controller read
+ * transaction while the transmit stream is empty. Data queued by
+ * `i2c_slave_write` supersedes it. Once the queued stream has been consumed and
+ * its read transaction completes, the default response is restored.
+ *
+ * A write queued while the default response is active is installed at a read
+ * transaction boundary. The controller may therefore receive the default once
+ * more before receiving the queued data. A later call to this function stages
+ * a replacement that is installed the next time the default is loaded.
+ *
+ * The default response must fit in the hardware FIFO. A controller must not
+ * read more bytes than the selected default or buffered response contains.
+ *
+ * @param[in] i2c_slave I2C slave device handle that created by `i2c_new_slave_device`.
+ * @param[in] data Response returned when no buffered transmit data is available.
+ * @param[in] len Response length in bytes. Must be between one and `SOC_I2C_FIFO_LEN`.
+ * @return
+ *      - ESP_OK: Response installed or staged successfully.
+ *      - ESP_ERR_INVALID_ARG: Parameter invalid or response does not fit in the FIFO.
+ *      - ESP_ERR_INVALID_STATE: A transmit callback or buffered transmit data is already active on the first call.
+ *      - ESP_ERR_NO_MEM: Allocation failed while enabling the default response.
+ *      - ESP_ERR_TIMEOUT: Another operation is in progress.
+ */
+esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const uint8_t *data, uint32_t len);
+
 #endif // CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2
 
 /**

--- a/components/esp_driver_i2c/include/driver/i2c_slave.h
+++ b/components/esp_driver_i2c/include/driver/i2c_slave.h
@@ -229,8 +229,8 @@ esp_err_t i2c_slave_set_default_response(i2c_slave_dev_handle_t i2c_slave, const
  * stretching. If disabled during a transaction already using the default
  * response, that transaction continues using it until its boundary.
  *
- * @param i2c_slave I2C slave device handle.
- * @param enabled Whether the default response should be served.
+ * @param[in] i2c_slave I2C slave device handle.
+ * @param[in] enabled Whether the default response should be served.
  * @return
  *      - ESP_OK: The mode was changed.
  *      - ESP_ERR_INVALID_ARG: The handle is invalid.
@@ -250,8 +250,8 @@ esp_err_t i2c_slave_set_default_response_enabled(i2c_slave_dev_handle_t i2c_slav
  *
  * This is a no-op on targets without response-time clock stretching.
  *
- * @param i2c_slave I2C slave device handle.
- * @param pending Whether more bytes of the current buffered response follow.
+ * @param[in] i2c_slave I2C slave device handle.
+ * @param[in] pending Whether more bytes of the current buffered response follow.
  * @return
  *      - ESP_OK: The state was changed.
  *      - ESP_ERR_INVALID_ARG: The handle is invalid.

--- a/components/esp_driver_i2c/test_apps/i2c_test_apps/main/test_i2c_slave_v2.c
+++ b/components/esp_driver_i2c/test_apps/i2c_test_apps/main/test_i2c_slave_v2.c
@@ -13,6 +13,7 @@
 #include "driver/i2c_master.h"
 #include "driver/i2c_slave.h"
 #include "esp_rom_gpio.h"
+#include "esp_rom_sys.h"
 #include "esp_log.h"
 #include "test_utils.h"
 #include "test_board.h"
@@ -420,5 +421,223 @@ static void slave_write_buffer_test_v2_single_byte(void)
 }
 
 TEST_CASE_MULTIPLE_DEVICES("I2C master read slave test single byte", "[i2c][test_env=generic_multi_device][timeout=150]", master_read_slave_test_v2_single_byte, slave_write_buffer_test_v2_single_byte);
+
+#define DEFAULT_RESPONSE_TEST_ITERATIONS 64
+#define DEFAULT_RESPONSE_TEST_LENGTH 64
+
+static const uint8_t s_default_response[] = { 0xd0, 0xd1, 0xd2, 0xd3 };
+static const uint8_t s_updated_default_response[] = { 0xe0, 0xe1, 0xe2 };
+
+static void master_default_response_test(void)
+{
+    i2c_master_bus_config_t bus_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = TEST_I2C_PORT,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_master_bus_handle_t bus;
+    TEST_ESP_OK(i2c_new_master_bus(&bus_config, &bus));
+
+    i2c_device_config_t device_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = ESP_SLAVE_ADDR,
+        .scl_speed_hz = 400000,
+        .scl_wait_us = 20000,
+    };
+    i2c_master_dev_handle_t device;
+    TEST_ESP_OK(i2c_master_bus_add_device(bus, &device_config, &device));
+
+    unity_wait_for_signal("default response target ready");
+    uint8_t default_data[sizeof(s_default_response)] = {};
+    TEST_ESP_OK(i2c_master_receive(device, default_data, sizeof(default_data), -1));
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(s_default_response, default_data, sizeof(default_data));
+    unity_send_signal("initial default consumed");
+
+    uint8_t explicit_data[DEFAULT_RESPONSE_TEST_LENGTH];
+    for (int iteration = 0; iteration < DEFAULT_RESPONSE_TEST_ITERATIONS; iteration++) {
+        unity_wait_for_signal("explicit response queued");
+        unity_send_signal("explicit read starting");
+        TEST_ESP_OK(i2c_master_receive(device, explicit_data, sizeof(explicit_data), -1));
+        for (size_t i = 0; i < sizeof(explicit_data); i++) {
+            TEST_ASSERT_EQUAL_HEX8((uint8_t)(iteration + i), explicit_data[i]);
+        }
+
+        memset(default_data, 0, sizeof(default_data));
+        TEST_ESP_OK(i2c_master_receive(device, default_data, sizeof(default_data), -1));
+        TEST_ASSERT_EQUAL_HEX8_ARRAY(s_default_response, default_data, sizeof(default_data));
+        unity_send_signal("explicit and fallback consumed");
+    }
+
+    unity_wait_for_signal("updated default ready");
+    uint8_t updated_default[sizeof(s_updated_default_response)] = {};
+    TEST_ESP_OK(i2c_master_receive(device, updated_default, sizeof(updated_default), -1));
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(s_updated_default_response, updated_default, sizeof(updated_default));
+    unity_send_signal("default response test complete");
+
+    TEST_ESP_OK(i2c_master_bus_rm_device(device));
+    TEST_ESP_OK(i2c_del_master_bus(bus));
+}
+
+static void slave_default_response_test(void)
+{
+    i2c_slave_config_t config = {
+        .i2c_port = TEST_I2C_PORT,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .scl_io_num = I2C_SLAVE_SCL_IO,
+        .sda_io_num = I2C_SLAVE_SDA_IO,
+        .slave_addr = ESP_SLAVE_ADDR,
+        .send_buf_depth = DEFAULT_RESPONSE_TEST_LENGTH * 2,
+        .receive_buf_depth = DATA_LENGTH,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_slave_dev_handle_t target;
+    TEST_ESP_OK(i2c_new_slave_device(&config, &target));
+    TEST_ESP_OK(i2c_slave_set_default_response(target, s_default_response, sizeof(s_default_response)));
+
+    unity_send_signal("default response target ready");
+    unity_wait_for_signal("initial default consumed");
+
+    uint8_t explicit_data[DEFAULT_RESPONSE_TEST_LENGTH];
+    for (int iteration = 0; iteration < DEFAULT_RESPONSE_TEST_ITERATIONS; iteration++) {
+        for (size_t i = 0; i < sizeof(explicit_data); i++) {
+            explicit_data[i] = (uint8_t)(iteration + i);
+        }
+
+        TEST_ESP_OK(i2c_slave_set_buffered_write_pending(target, true));
+        uint32_t written = 0;
+        TEST_ESP_OK(i2c_slave_write(target, explicit_data, sizeof(explicit_data), &written, -1));
+        TEST_ASSERT_EQUAL(sizeof(explicit_data), written);
+        unity_send_signal("explicit response queued");
+        unity_wait_for_signal("explicit read starting");
+
+        // Sweep across the first FIFO-drain boundary. This stresses arbitration
+        // between TX_EMPTY on one core and clearing the producer state here.
+        esp_rom_delay_us(500 + (iteration % 16) * 40);
+        TEST_ESP_OK(i2c_slave_set_buffered_write_pending(target, false));
+        unity_wait_for_signal("explicit and fallback consumed");
+    }
+
+    TEST_ESP_OK(i2c_slave_set_default_response(target, s_updated_default_response, sizeof(s_updated_default_response)));
+    unity_send_signal("updated default ready");
+    unity_wait_for_signal("default response test complete");
+    TEST_ESP_OK(i2c_del_slave_device(target));
+}
+
+TEST_CASE_MULTIPLE_DEVICES("I2C slave default response arbitration", "[i2c][test_env=generic_multi_device][timeout=300]", master_default_response_test, slave_default_response_test);
+
+static DRAM_ATTR uint8_t s_callback_response[64];
+static volatile size_t s_callback_response_offset;
+static volatile size_t s_callback_transmitted;
+static SemaphoreHandle_t s_callback_done;
+
+static IRAM_ATTR bool slave_transmit_callback(i2c_slave_dev_handle_t target,
+                                              i2c_slave_transmit_event_data_t *event,
+                                              void *context)
+{
+    size_t remaining = sizeof(s_callback_response) - s_callback_response_offset;
+    size_t length = event->buffer_size < remaining ? event->buffer_size : remaining;
+    event->buffer = &s_callback_response[s_callback_response_offset];
+    event->length = length;
+    s_callback_response_offset += length;
+    return false;
+}
+
+static IRAM_ATTR bool slave_transmit_done_callback(i2c_slave_dev_handle_t target,
+                                                   const i2c_slave_transmit_done_event_data_t *event,
+                                                   void *context)
+{
+    BaseType_t task_woken = pdFALSE;
+    s_callback_transmitted = event->length;
+    s_callback_response_offset = 0;
+    xSemaphoreGiveFromISR(s_callback_done, &task_woken);
+    return task_woken == pdTRUE;
+}
+
+static const size_t s_callback_read_lengths[] = { 1, 7, 31, 32, 47 };
+
+static void master_synchronous_callback_test(void)
+{
+    i2c_master_bus_config_t bus_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = TEST_I2C_PORT,
+        .scl_io_num = I2C_MASTER_SCL_IO,
+        .sda_io_num = I2C_MASTER_SDA_IO,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_master_bus_handle_t bus;
+    TEST_ESP_OK(i2c_new_master_bus(&bus_config, &bus));
+
+    i2c_device_config_t device_config = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = ESP_SLAVE_ADDR,
+        .scl_speed_hz = 400000,
+        .scl_wait_us = 20000,
+    };
+    i2c_master_dev_handle_t device;
+    TEST_ESP_OK(i2c_master_bus_add_device(bus, &device_config, &device));
+
+    unity_wait_for_signal("synchronous callback target ready");
+    uint8_t received[sizeof(s_callback_response)];
+    for (size_t iteration = 0; iteration < sizeof(s_callback_read_lengths) / sizeof(s_callback_read_lengths[0]); iteration++) {
+        size_t length = s_callback_read_lengths[iteration];
+        memset(received, 0, sizeof(received));
+        TEST_ESP_OK(i2c_master_receive(device, received, length, -1));
+        for (size_t i = 0; i < length; i++) {
+            TEST_ASSERT_EQUAL_HEX8((uint8_t)(0x40 + i), received[i]);
+        }
+        unity_send_signal("synchronous callback read complete");
+        unity_wait_for_signal("synchronous callback checked");
+    }
+
+    TEST_ESP_OK(i2c_master_bus_rm_device(device));
+    TEST_ESP_OK(i2c_del_master_bus(bus));
+}
+
+static void slave_synchronous_callback_test(void)
+{
+    i2c_slave_config_t config = {
+        .i2c_port = TEST_I2C_PORT,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .scl_io_num = I2C_SLAVE_SCL_IO,
+        .sda_io_num = I2C_SLAVE_SDA_IO,
+        .slave_addr = ESP_SLAVE_ADDR,
+        .send_buf_depth = sizeof(s_callback_response),
+        .receive_buf_depth = DATA_LENGTH,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_slave_dev_handle_t target;
+    TEST_ESP_OK(i2c_new_slave_device(&config, &target));
+
+    for (size_t i = 0; i < sizeof(s_callback_response); i++) {
+        s_callback_response[i] = (uint8_t)(0x40 + i);
+    }
+    s_callback_response_offset = 0;
+    s_callback_transmitted = 0;
+    s_callback_done = xSemaphoreCreateBinary();
+    TEST_ASSERT_NOT_NULL(s_callback_done);
+
+    i2c_slave_event_callbacks_t callbacks = {
+        .on_transmit = slave_transmit_callback,
+        .on_transmit_done = slave_transmit_done_callback,
+    };
+    TEST_ESP_OK(i2c_slave_register_event_callbacks(target, &callbacks, NULL));
+    unity_send_signal("synchronous callback target ready");
+
+    for (size_t iteration = 0; iteration < sizeof(s_callback_read_lengths) / sizeof(s_callback_read_lengths[0]); iteration++) {
+        TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(s_callback_done, pdMS_TO_TICKS(1000)));
+        TEST_ASSERT_EQUAL(s_callback_read_lengths[iteration], s_callback_transmitted);
+        unity_wait_for_signal("synchronous callback read complete");
+        unity_send_signal("synchronous callback checked");
+    }
+
+    TEST_ESP_OK(i2c_slave_register_event_callbacks(target, &(i2c_slave_event_callbacks_t) {}, NULL));
+    vSemaphoreDelete(s_callback_done);
+    s_callback_done = NULL;
+    TEST_ESP_OK(i2c_del_slave_device(target));
+}
+
+TEST_CASE_MULTIPLE_DEVICES("I2C slave synchronous transmit callbacks", "[i2c][test_env=generic_multi_device][timeout=150]", master_synchronous_callback_test, slave_synchronous_callback_test);
 
 #endif // SOC_I2C_SLAVE_CAN_GET_STRETCH_CAUSE

--- a/components/esp_driver_spi/include/driver/spi_master.h
+++ b/components/esp_driver_spi/include/driver/spi_master.h
@@ -71,7 +71,7 @@ typedef struct {
     spi_clock_source_t clock_source;///< Select SPI clock source, `SPI_CLK_SRC_DEFAULT` by default.
     uint16_t duty_cycle_pos;        ///< Duty cycle of positive clock, in 1/256th increments (128 = 50%/50% duty). Setting this to 0 (=not setting it) is equivalent to setting this to 128.
     uint16_t cs_ena_pretrans;       ///< Amount of SPI bit-cycles the cs should be activated before the transmission (0-16). This only works on half-duplex transactions.
-    uint8_t cs_ena_posttrans;       ///< Amount of SPI bit-cycles the cs should stay active after the transmission (0-16)
+    uint8_t cs_ena_posttrans;       ///< Amount of SPI bit-cycles the cs should stay active after the transmission (0-16, 0-15 on ESP32)
     int clock_speed_hz;             ///< SPI clock speed in Hz. Derived from `clock_source`.
     int input_delay_ns;             /**< Maximum data valid time of slave. The time required between SCLK and MISO
         valid, including the possible clock delay from slave to master. The driver uses this value to give an extra

--- a/components/esp_driver_spi/src/gpspi/spi_master.c
+++ b/components/esp_driver_spi/src/gpspi/spi_master.c
@@ -451,6 +451,7 @@ esp_err_t spi_bus_add_device(spi_host_device_t host_id, const spi_device_interfa
     //duplex mode does absolutely nothing on the ESP32.
     SPI_CHECK(dev_config->cs_ena_pretrans <= 1 || (dev_config->address_bits == 0 && dev_config->command_bits == 0) ||
               (dev_config->flags & SPI_DEVICE_HALFDUPLEX), "In full-duplex mode, only support cs pretrans delay = 1 and without address_bits and command_bits", ESP_ERR_INVALID_ARG);
+    SPI_CHECK(dev_config->cs_ena_posttrans <= 15, "cs posttrans delay exceeds the hardware limit", ESP_ERR_INVALID_ARG);
 #endif
 
     //Check post_cb status when `SPI_DEVICE_NO_RETURN_RESULT` flag is set.

--- a/components/esp_driver_spi/src/gpspi/spi_master.c
+++ b/components/esp_driver_spi/src/gpspi/spi_master.c
@@ -1306,17 +1306,9 @@ esp_err_t SPI_MASTER_ATTR spi_device_transmit(spi_device_handle_t handle, spi_tr
     return ESP_OK;
 }
 
-static esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus_internal(spi_device_t *device, bool try_only, TickType_t wait)
+static esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus_finish(spi_device_t *device)
 {
     spi_host_t *const host = device->host;
-    SPI_CHECK(!spi_bus_device_is_polling(device), "Cannot acquire bus when a polling transaction is in progress.", ESP_ERR_INVALID_STATE);
-
-    esp_err_t ret = try_only
-        ? spi_bus_lock_try_acquire_start(device->dev_lock)
-        : spi_bus_lock_acquire_start(device->dev_lock, wait);
-    if (ret != ESP_OK) {
-        return ret;
-    }
     host->device_acquiring_lock = device;
 
     ESP_LOGD(SPI_TAG, "device%d locked the bus", device->id);
@@ -1343,12 +1335,24 @@ static esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus_internal(spi_device_
 esp_err_t SPI_MASTER_ISR_ATTR spi_device_acquire_bus(spi_device_t *device, TickType_t wait)
 {
     SPI_CHECK(wait == portMAX_DELAY, "acquire finite time not supported now.", ESP_ERR_INVALID_ARG);
-    return spi_device_acquire_bus_internal(device, false, wait);
+    SPI_CHECK(!spi_bus_device_is_polling(device), "Cannot acquire bus when a polling transaction is in progress.", ESP_ERR_INVALID_STATE);
+
+    esp_err_t ret = spi_bus_lock_acquire_start(device->dev_lock, wait);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    return spi_device_acquire_bus_finish(device);
 }
 
-esp_err_t SPI_MASTER_ISR_ATTR spi_device_try_acquire_bus(spi_device_t *device)
+esp_err_t spi_device_try_acquire_bus(spi_device_t *device)
 {
-    return spi_device_acquire_bus_internal(device, true, 0);
+    SPI_CHECK(!spi_bus_device_is_polling(device), "Cannot acquire bus when a polling transaction is in progress.", ESP_ERR_INVALID_STATE);
+
+    esp_err_t ret = spi_bus_lock_try_acquire_start(device->dev_lock);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+    return spi_device_acquire_bus_finish(device);
 }
 
 // This function restore configurations required in the non-polling mode

--- a/components/esp_driver_spi/src/gpspi/spi_slave.c
+++ b/components/esp_driver_spi/src/gpspi/spi_slave.c
@@ -679,8 +679,13 @@ static void SPI_SLAVE_ISR_ATTR s_spi_slave_prepare_data(spi_slave_t *host)
     spi_slave_hal_set_trans_bitlen(hal);
 
 #ifdef CONFIG_IDF_TARGET_ESP32
-    //SPI Slave mode on ESP32 requires MOSI/MISO enable
+    // SPI Slave mode on ESP32 requires MOSI/MISO enable.
     spi_slave_hal_enable_data_line(hal);
+#endif
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+    bool receive_enabled = host->bus_config.mosi_io_num >= 0;
+    bool transmit_enabled = host->bus_config.miso_io_num >= 0;
+    spi_slave_hal_select_data_line_edges(hal, receive_enabled, transmit_enabled);
 #endif
 }
 

--- a/components/esp_driver_spi/src/gpspi/spi_slave.c
+++ b/components/esp_driver_spi/src/gpspi/spi_slave.c
@@ -461,6 +461,7 @@ esp_err_t SPI_SLAVE_ATTR spi_slave_queue_trans(spi_host_device_t host, const spi
 
     r = xQueueSend(spihost[host]->trans_queue, (void *)&priv_trans, ticks_to_wait);
     if (!r) {
+        spi_slave_uninstall_priv_trans(host, &priv_trans);
         return ESP_ERR_TIMEOUT;
     }
     esp_intr_enable(spihost[host]->intr);

--- a/components/esp_driver_spi/test_apps/master/main/test_spi_master.c
+++ b/components/esp_driver_spi/test_apps/master/main/test_spi_master.c
@@ -361,6 +361,26 @@ TEST_CASE("SPI Master test, interaction of multiple devs", "[spi]")
     TEST_ASSERT(success);
 }
 
+#if CONFIG_IDF_TARGET_ESP32
+TEST_CASE("SPI master validates the CS posttrans delay", "[spi]")
+{
+    spi_bus_config_t buscfg = SPI_BUS_TEST_DEFAULT_CONFIG();
+    spi_device_interface_config_t devcfg = SPI_DEVICE_TEST_DEFAULT_CONFIG();
+    spi_device_handle_t handle;
+
+    TEST_ESP_OK(spi_bus_initialize(TEST_SPI_HOST, &buscfg, SPI_DMA_CH_AUTO));
+
+    devcfg.cs_ena_posttrans = 15;
+    TEST_ESP_OK(spi_bus_add_device(TEST_SPI_HOST, &devcfg, &handle));
+    TEST_ESP_OK(spi_bus_remove_device(handle));
+
+    devcfg.cs_ena_posttrans = 16;
+    TEST_ESP_ERR(ESP_ERR_INVALID_ARG, spi_bus_add_device(TEST_SPI_HOST, &devcfg, &handle));
+
+    TEST_ESP_OK(spi_bus_free(TEST_SPI_HOST));
+}
+#endif
+
 #if TEST_SOC_HAS_INPUT_ONLY_PINS  //There is no input-only pin, so this test could be ignored.
 static esp_err_t test_master_pins(int mosi, int miso, int sclk, int cs)
 {

--- a/components/esp_driver_spi/test_apps/slave/main/test_spi_slave.c
+++ b/components/esp_driver_spi/test_apps/slave/main/test_spi_slave.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include "sdkconfig.h"
 #include "unity.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "test_utils.h"
 #include "test_spi_utils.h"
 #include "hal/spi_slave_hal.h"
@@ -35,6 +37,17 @@ static WORD_ALIGNED_ATTR uint8_t slave_rxbuf[320];
 
 static const uint8_t master_send[] = { 0x93, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0xaa, 0xcc, 0xff, 0xee, 0x55, 0x77, 0x88, 0x43 };
 static const uint8_t slave_send[] = { 0xaa, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10, 0x13, 0x57, 0x9b, 0xdf, 0x24, 0x68, 0xac, 0xe0 };
+
+static SemaphoreHandle_t s_slave_armed;
+
+static IRAM_ATTR void slave_armed_callback(spi_slave_transaction_t *transaction)
+{
+    BaseType_t task_woken = pdFALSE;
+    xSemaphoreGiveFromISR(s_slave_armed, &task_woken);
+    if (task_woken == pdTRUE) {
+        portYIELD_FROM_ISR();
+    }
+}
 
 static void custom_setup(void)
 {
@@ -298,6 +311,79 @@ TEST_CASE("test slave send unaligned", "[spi]")
     custom_teardown();
 
     ESP_LOGI(SLAVE_TAG, "test passed.");
+}
+
+static void test_slave_abort_and_reuse(spi_dma_chan_t dma_channel)
+{
+    spi_bus_config_t bus_config = SPI_BUS_TEST_DEFAULT_CONFIG();
+    bus_config.flags |= SPICOMMON_BUSFLAG_GPIO_PINS;
+    spi_device_interface_config_t device_config = {
+        .clock_speed_hz = 4 * 1000 * 1000,
+        .mode = 0,
+        .spics_io_num = PIN_NUM_CS,
+        .queue_size = 1,
+    };
+    spi_slave_interface_config_t slave_config = SPI_SLAVE_TEST_DEFAULT_CONFIG();
+    slave_config.queue_size = 1;
+    slave_config.post_setup_cb = slave_armed_callback;
+
+    s_slave_armed = xSemaphoreCreateBinary();
+    TEST_ASSERT_NOT_NULL(s_slave_armed);
+    TEST_ESP_OK(spi_bus_initialize(TEST_SPI_HOST, &bus_config, dma_channel));
+    TEST_ESP_OK(spi_bus_add_device(TEST_SPI_HOST, &device_config, &spi));
+    TEST_ESP_OK(spi_slave_initialize(TEST_SLAVE_HOST, &bus_config, &slave_config, dma_channel));
+    same_pin_func_sel(bus_config, device_config, 0);
+
+    WORD_ALIGNED_ATTR uint8_t tx_data[16];
+    WORD_ALIGNED_ATTR uint8_t rx_data[16];
+    for (size_t i = 0; i < sizeof(tx_data); i++) {
+        tx_data[i] = (uint8_t)(0x80 + i);
+        rx_data[i] = 0;
+    }
+    spi_slave_transaction_t slave_transaction = {
+        .length = sizeof(tx_data) * 8,
+        .rx_buffer = rx_data,
+    };
+    if (dma_channel != SPI_DMA_DISABLED) {
+        slave_transaction.flags = SPI_SLAVE_TRANS_DMA_BUFFER_ALIGN_AUTO;
+    }
+
+    TEST_ESP_OK(spi_slave_queue_trans(TEST_SLAVE_HOST, &slave_transaction, portMAX_DELAY));
+    TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(s_slave_armed, pdMS_TO_TICKS(1000)));
+    TEST_ESP_ERR(ESP_ERR_INVALID_STATE, spi_slave_free(TEST_SLAVE_HOST));
+    TEST_ESP_OK(spi_slave_abort_transaction(TEST_SLAVE_HOST, &slave_transaction));
+
+    spi_slave_transaction_t *completed = NULL;
+    TEST_ESP_OK(spi_slave_get_trans_result(TEST_SLAVE_HOST, &completed, pdMS_TO_TICKS(1000)));
+    TEST_ASSERT_EQUAL_PTR(&slave_transaction, completed);
+    TEST_ASSERT_EQUAL(0, slave_transaction.trans_len);
+
+    memset(rx_data, 0, sizeof(rx_data));
+    slave_transaction.trans_len = 0;
+    TEST_ESP_OK(spi_slave_queue_trans(TEST_SLAVE_HOST, &slave_transaction, portMAX_DELAY));
+    TEST_ASSERT_EQUAL(pdTRUE, xSemaphoreTake(s_slave_armed, pdMS_TO_TICKS(1000)));
+
+    spi_transaction_t master_transaction = {
+        .length = sizeof(tx_data) * 8,
+        .tx_buffer = tx_data,
+    };
+    TEST_ESP_OK(spi_device_transmit(spi, &master_transaction));
+    TEST_ESP_OK(spi_slave_get_trans_result(TEST_SLAVE_HOST, &completed, pdMS_TO_TICKS(1000)));
+    TEST_ASSERT_EQUAL_PTR(&slave_transaction, completed);
+    TEST_ASSERT_EQUAL(sizeof(tx_data) * 8, slave_transaction.trans_len);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(tx_data, rx_data, sizeof(tx_data));
+
+    TEST_ESP_OK(spi_slave_free(TEST_SLAVE_HOST));
+    TEST_ESP_OK(spi_bus_remove_device(spi));
+    TEST_ESP_OK(spi_bus_free(TEST_SPI_HOST));
+    vSemaphoreDelete(s_slave_armed);
+    s_slave_armed = NULL;
+}
+
+TEST_CASE("SPI slave abort retires transaction and permits reuse", "[spi]")
+{
+    test_slave_abort_and_reuse(SPI_DMA_DISABLED);
+    test_slave_abort_and_reuse(SPI_DMA_CH_AUTO);
 }
 
 #endif // !CONFIG_SPIRAM

--- a/components/esp_hw_support/spi_bus_lock.c
+++ b/components/esp_hw_support/spi_bus_lock.c
@@ -748,7 +748,7 @@ IRAM_ATTR esp_err_t spi_bus_lock_acquire_start(spi_bus_lock_dev_t *dev_handle, T
     return ESP_OK;
 }
 
-IRAM_ATTR esp_err_t spi_bus_lock_try_acquire_start(spi_bus_lock_dev_t *dev_handle)
+esp_err_t spi_bus_lock_try_acquire_start(spi_bus_lock_dev_t *dev_handle)
 {
     spi_bus_lock_t* lock = dev_handle->parent;
 

--- a/components/hal/esp32/include/hal/i2c_ll.h
+++ b/components/hal/esp32/include/hal/i2c_ll.h
@@ -1011,6 +1011,7 @@ static inline void i2c_ll_master_get_event(i2c_dev_t *hw, i2c_intr_event_t *even
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32/include/hal/spi_ll.h
+++ b/components/hal/esp32/include/hal/spi_ll.h
@@ -829,6 +829,8 @@ static inline void spi_ll_set_dummy(spi_dev_t *hw, int dummy_n)
  */
 static inline void spi_ll_master_set_cs_hold(spi_dev_t *hw, int hold)
 {
+    // The reset value limits the effective hold phase to six SPI clocks.
+    hw->ctrl1.cs_hold_delay = hold ? hold - 1 : 0;
     hw->ctrl2.hold_time = hold;
     hw->user.cs_hold = hold ? 1 : 0;
 }

--- a/components/hal/esp32c3/include/hal/i2c_ll.h
+++ b/components/hal/esp32c3/include/hal/i2c_ll.h
@@ -1162,6 +1162,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32c5/include/hal/i2c_ll.h
+++ b/components/hal/esp32c5/include/hal/i2c_ll.h
@@ -1201,6 +1201,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32c6/include/hal/i2c_ll.h
+++ b/components/hal/esp32c6/include/hal/i2c_ll.h
@@ -1203,6 +1203,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32c61/include/hal/i2c_ll.h
+++ b/components/hal/esp32c61/include/hal/i2c_ll.h
@@ -1114,6 +1114,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32h2/include/hal/i2c_ll.h
+++ b/components/hal/esp32h2/include/hal/i2c_ll.h
@@ -1111,6 +1111,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32p4/include/hal/i2c_ll.h
+++ b/components/hal/esp32p4/include/hal/i2c_ll.h
@@ -1234,6 +1234,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32s2/include/hal/i2c_ll.h
+++ b/components/hal/esp32s2/include/hal/i2c_ll.h
@@ -1119,6 +1119,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= I2C_LL_SLAVE_TX_INT;

--- a/components/hal/esp32s3/include/hal/i2c_ll.h
+++ b/components/hal/esp32s3/include/hal/i2c_ll.h
@@ -1166,6 +1166,7 @@ static inline void i2c_ll_master_disable_rx_it(i2c_dev_t *hw)
  *
  * @return None
  */
+__attribute__((always_inline))
 static inline void i2c_ll_slave_enable_tx_it(i2c_dev_t *hw)
 {
     hw->int_ena.val |= 0x2;

--- a/components/hal/esp32s3/include/hal/spi_ll.h
+++ b/components/hal/esp32s3/include/hal/spi_ll.h
@@ -619,9 +619,20 @@ static inline void spi_ll_slave_set_mode(spi_dev_t *hw, const int mode, bool dma
         hw->user.tsck_i_edge = 0;
         hw->slave.clk_mode_13 = 1;
     }
-    // In non-DMA mode 2, outputting on RSCK makes the first bit valid before
-    // the controller's leading edge. DMA uses the edge selection above.
-    hw->slave.rsck_data_out = mode == 2 && !dma_used;
+    hw->slave.rsck_data_out = 0;
+}
+
+/**
+ * Select the slave mode-2 receive and transmit edges.
+ *
+ * @param hw     Beginning address of the peripheral registers.
+ * @param edge   Internal edge value for both data lines.
+ */
+static inline void spi_ll_slave_set_mode2_data_line_edges(spi_dev_t *hw, bool edge)
+{
+    hw->user.rsck_i_edge = edge;
+    hw->user.tsck_i_edge = edge;
+    hw->slave.rsck_data_out = 0;
 }
 
 /**

--- a/components/hal/include/hal/spi_slave_hal.h
+++ b/components/hal/include/hal/spi_slave_hal.h
@@ -162,6 +162,17 @@ void spi_slave_hal_set_trans_bitlen(spi_slave_hal_context_t *hal);
 void spi_slave_hal_enable_data_line(spi_slave_hal_context_t *hal);
 
 /**
+ * Select the slave data-line edges for the current bus configuration.
+ *
+ * @param hal              Context of the HAL layer.
+ * @param receive_enabled  Whether MOSI is connected.
+ * @param transmit_enabled Whether MISO is connected.
+ */
+void spi_slave_hal_select_data_line_edges(spi_slave_hal_context_t *hal,
+                                          bool receive_enabled,
+                                          bool transmit_enabled);
+
+/**
  * Trigger start a user-defined transaction.
  *
  * @param hal Context of the HAL layer.

--- a/components/hal/spi_slave_hal_iram.c
+++ b/components/hal/spi_slave_hal_iram.c
@@ -57,6 +57,26 @@ void spi_slave_hal_enable_data_line(spi_slave_hal_context_t *hal)
     spi_ll_enable_miso(hal->hw, (hal->tx_buffer != NULL));
 }
 
+void spi_slave_hal_select_data_line_edges(spi_slave_hal_context_t *hal,
+                                          bool receive_enabled,
+                                          bool transmit_enabled)
+{
+#if CONFIG_IDF_TARGET_ESP32S3
+    if (hal->mode == 2 && !hal->use_dma) {
+        // Coupling TX to the RX clock shifts a single active data line by one
+        // bit. Keep the mode-2 full-duplex edges, but use the DMA edge setting
+        // when only one data line is connected.
+        bool full_duplex = receive_enabled && transmit_enabled;
+        spi_ll_slave_set_mode2_data_line_edges(hal->hw, full_duplex);
+        spi_ll_apply_config(hal->hw);
+    }
+#else
+    (void) hal;
+    (void) receive_enabled;
+    (void) transmit_enabled;
+#endif
+}
+
 void spi_slave_hal_store_result(spi_slave_hal_context_t *hal)
 {
     //when data of cur_trans->length are all sent, the slv_rdata_bit


### PR DESCRIPTION
This follow-up contains issues found by the expanded Toit hardware tests and a full SDK-style review of the asynchronous I2C/SPI paths:

- Keep an async I2C target stretching SCL while a requested response is still pending, including short responses that fit entirely in the hardware FIFO.
- Add a bounded I2C target default response for chips such as the original ESP32 that cannot stretch while application code prepares data. Buffered writes supersede the default at a read-transaction boundary; when the buffered stream drains, the driver restores the default automatically without mixing responses within a transaction.
- Serialize target default-response state changes with active callbacks and make teardown ordering safe.
- Fix queue allocation/deallocation mismatches and SPI target descriptor leaks on failure paths.
- Keep ISR code and callees correctly attributed for IRAM-safe configurations while reducing the SPI master/task-lock IRAM footprint enough to retain `CONFIG_SPI_MASTER_ISR_IN_IRAM=y` on classic ESP32.
- Program the classic ESP32 SPI CS-hold field without the off-by-one used by the other chips.
- On ESP32-S3 non-DMA mode 2, select the internal data-line edge from the connected MOSI/MISO directions. This avoids one-bit shifts in both single-direction and full-duplex targets.

I compared these paths with a recent ESP-IDF master checkout. The Toit fork is staying on ESP-IDF 5.4; moving to the newer upstream I2C API would require a substantially larger 6.x migration. The remaining private-fork changes are therefore kept narrow and maintainable.

The original ESP32 ACKs an empty target read but returns undefined FIFO contents; an observed eight-byte read was `b5 ff ff ff ff ff ff ff`. The default-response path makes that case deterministic.

Verification:

- ESP32: complete paired-board I2C/SPI selection 15/15 after setup and 12/12 immediately without setup.
- ESP32-S3: complete paired-board I2C/SPI selection 15/15 after setup and 12/12 immediately without setup.
- Focused default-response tests pass on both variants, including short dynamic responses and switching back to the fallback response.
- Independent RMT probes verify every supported CS setup/hold value and exactly 32 clocks per transfer.
- Native ESP32 and ESP32-S3 I2C builds pass with IRAM-safe options enabled.
- Native classic-ESP32 SPI target and SPI master builds pass with their ISR IRAM options enabled.
- The dependent Toit default envelope links on classic ESP32 with both I2C/SPI targets enabled and `CONFIG_SPI_MASTER_ISR_IN_IRAM=y`.
